### PR TITLE
[Fefactor and Fix] Refactor v0.0.3 and fix CLI issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help install lint typecheck test test-all test-remote clean build publish
+.PHONY: help install lint typecheck test test-cli test-all test-remote clean build publish
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -21,6 +21,9 @@ typecheck: ## Run mypy type checking
 
 test: ## Run unit tests only (no remote API calls)
 	pytest tests/ -k "not remote" --ignore=tests/integration
+
+test-cli: ## Run CLI unit tests only (no remote API calls)
+	python tests/cli/run_all.py
 
 test-all: ## Run all tests including integration (needs tests/.env)
 	pytest tests/

--- a/README.md
+++ b/README.md
@@ -132,14 +132,17 @@ api.stop_repo("my-org/chat-demo", "studio")
 
 The CLI is available as both `ms` and `modelscope`.
 
-**Global options** (placed before the subcommand):
+**Global options** (placed before or after the subcommand):
 
 | Option | Description |
 |--------|-------------|
 | `--token TOKEN` | API token (overrides env and persisted token) |
 | `--endpoint URL` | API endpoint (default: `https://modelscope.cn`) |
-| `-v, --verbose` | Enable DEBUG logging |
-| `-V, --version` | Print version and exit |
+| `-v, --verbose` | Enable DEBUG logging (global only) |
+| `-V, --version` | Print version and exit (global only) |
+
+> `--token` and `--endpoint` can be placed either before or after the subcommand:
+> `ms --token xxx download ...` and `ms download ... --token xxx` are equivalent.
 
 ### `ms login`
 
@@ -160,6 +163,7 @@ Show the user associated with the current token.
 
 ```bash
 ms whoami
+ms whoami --token $MY_TOKEN   # check a specific token without logging in
 ```
 
 ### `ms download`
@@ -205,9 +209,6 @@ ms download Qwen/Qwen3-0.6B --cache-dir /data/hub-cache --max-workers 8
 
 # Force re-download even if already cached
 ms download Qwen/Qwen3-0.6B config.json --force
-
-# Download a Studio space
-ms download my-org/chat-demo --repo-type studio
 
 # Download all skills from a collection (legacy flag)
 ms download --collection my-org/skill-collection

--- a/README.md
+++ b/README.md
@@ -116,13 +116,13 @@ api.create_repo("my-org/my-model", "model", visibility="private", license="apach
 
 ```bash
 ms deploy my-org/chat-demo --repo-type studio
-ms logs my-org/chat-demo --log-type runtime
+ms logs my-org/chat-demo --log-type run
 ms stop my-org/chat-demo --repo-type studio
 ```
 
 ```python
 api.deploy_repo("my-org/chat-demo", "studio")
-api.get_repo_logs("my-org/chat-demo", log_type="runtime")
+api.get_repo_logs("my-org/chat-demo", log_type="run")
 api.stop_repo("my-org/chat-demo", "studio")
 ```
 
@@ -321,7 +321,7 @@ Manage Studio and MCP deployments.
 
 ```bash
 ms deploy my-org/chat-demo --repo-type studio
-ms logs my-org/chat-demo --log-type runtime --keyword ERROR --page-size 50
+ms logs my-org/chat-demo --log-type run --keyword ERROR --page-size 50
 ms settings my-org/chat-demo cpu=4 memory=8192
 ms stop my-org/chat-demo --repo-type studio
 ```
@@ -333,7 +333,7 @@ ms stop my-org/chat-demo --repo-type studio
 |---------|-------------|
 | `ms deploy <repo_id>` | `--repo-type {studio,mcp}` |
 | `ms stop <repo_id>` | `--repo-type {studio,mcp}` |
-| `ms logs <repo_id>` | `--log-type {runtime,build}`, `--keyword`, `--page`, `--page-size` |
+| `ms logs <repo_id>` | `--log-type {run,build}`, `--keyword`, `--page`, `--page-size` |
 | `ms settings <repo_id> key=val...` | Key-value pairs passed to backend |
 
 </details>

--- a/README.md
+++ b/README.md
@@ -330,12 +330,15 @@ ms stop my-org/chat-demo --repo-type studio
 <details>
 <summary>Options</summary>
 
-| Command | Key Options |
-|---------|-------------|
-| `ms deploy <repo_id>` | `--repo-type {studio,mcp}` |
-| `ms stop <repo_id>` | `--repo-type {studio,mcp}` |
-| `ms logs <repo_id>` | `--log-type {run,build}`, `--keyword`, `--page`, `--page-size` |
-| `ms settings <repo_id> key=val...` | Key-value pairs passed to backend |
+| Command | `--repo-type` | Key Options |
+|---------|---------------|-------------|
+| `ms deploy <repo_id>` | `{studio,mcp}` (default: `studio`) | — |
+| `ms stop <repo_id>` | `{studio,mcp}` (default: `studio`) | — |
+| `ms logs <repo_id>` | `{studio}` only | `--log-type {run,build}`, `--keyword`, `--page`, `--page-size` |
+| `ms settings <repo_id> key=val...` | `{studio,skill}` (default: `studio`) | Key-value pairs passed to backend |
+
+> **Note:** `ms logs` only supports Studio spaces. MCP server logs are not available via this command.
+> `ms settings` supports Studio and Skill repos; for MCP servers use `ms mcp deploy` with configuration payload.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ api.upload_folder("my-org/my-model", "model", "./output", path_in_repo="")
 ### Create a Repository
 
 ```bash
-ms repo create my-org/my-model --repo-type model --visibility private
+ms create my-org/my-model --repo-type model --visibility private
 ```
 
 ```python
@@ -283,25 +283,25 @@ ms upload my-org/my-model ./output --disable-tqdm
 
 </details>
 
-### `ms repo`
+### `ms create` / `ms info` / `ms list` / `ms delete`
 
-Repository management (create, info, list, delete).
+Repository management.
 
 ```bash
-ms repo create my-org/my-model --repo-type model --visibility private
-ms repo create my-org/demo --repo-type studio --sdk-type gradio
-ms repo info my-org/my-model --repo-type model
-ms repo list --repo-type model --owner my-org --page-size 20
-ms repo delete my-org/my-model --repo-type model --yes
+ms create my-org/my-model --repo-type model --visibility private
+ms create my-org/demo --repo-type studio --sdk-type gradio
+ms info my-org/my-model --repo-type model
+ms list --repo-type model --owner my-org --page-size 20
+ms delete my-org/my-model --repo-type model --yes
 ```
 
 <details>
-<summary><code>ms repo create</code> options</summary>
+<summary><code>ms create</code> options</summary>
 
 | Argument / Option | Required | Description |
 |-------------------|----------|-------------|
 | `repo_id` | yes | Repository identifier |
-| `--repo-type` | yes | `model`, `dataset`, `studio`, `skill`, or `mcp` |
+| `--repo-type` | yes | `model`, `dataset`, `studio`, or `skill` |
 | `--visibility` | no | `public`, `private`, or `internal` |
 | `--license` | no | SPDX license identifier (e.g. `apache-2.0`) |
 | `--chinese-name` | no | Display name in Chinese |

--- a/src/modelscope_hub/_legacy_api.py
+++ b/src/modelscope_hub/_legacy_api.py
@@ -242,7 +242,8 @@ class LegacyClient:
     ) -> list[dict]:
         """List files in a repository.
 
-        GET /api/v1/{type}s/{repo_id}/repo/files?Revision=&Recursive=&Root=
+        Models/studios/etc: GET /api/v1/{type}s/{repo_id}/repo/files
+        Datasets: GET /api/v1/datasets/{repo_id}/repo/tree
         """
         segment = _resolve_segment(repo_type)
         params: dict[str, Any] = {
@@ -252,7 +253,8 @@ class LegacyClient:
         if root:
             params["Root"] = root
 
-        resp = self._request("GET", f"{segment}/{repo_id}/repo/files", params=params)
+        suffix = "repo/tree" if repo_type in ("dataset", "datasets") else "repo/files"
+        resp = self._request("GET", f"{segment}/{repo_id}/{suffix}", params=params)
         data = self._json_data(resp)
         if isinstance(data, list):
             return data
@@ -271,7 +273,7 @@ class LegacyClient:
         """List files in a dataset repo using pagination.
 
         Datasets can have millions of files, so this method pages through
-        ``GET /api/v1/datasets/{repo_id}/repo/files`` with
+        ``GET /api/v1/datasets/{repo_id}/repo/tree`` with
         ``PageNumber``/``PageSize`` params.
         """
         all_files: list[dict] = []
@@ -287,7 +289,7 @@ class LegacyClient:
                 params["Root"] = root_path
             resp = self._request(
                 "GET",
-                f"datasets/{repo_id}/repo/files",
+                f"datasets/{repo_id}/repo/tree",
                 params=params,
             )
             data = self._json_data(resp)

--- a/src/modelscope_hub/_legacy_api.py
+++ b/src/modelscope_hub/_legacy_api.py
@@ -272,7 +272,7 @@ class LegacyClient:
         if root:
             params["Root"] = root
 
-        suffix = "repo/tree" if repo_type in ("dataset", "datasets") else "repo/files"
+        suffix = "repo/tree" if repo_type in (RepoType.DATASET, "dataset", "datasets") else "repo/files"
         resp = self._request("GET", f"{segment}/{repo_id}/{suffix}", params=params)
         data = self._json_data(resp)
         if isinstance(data, list):

--- a/src/modelscope_hub/_legacy_api.py
+++ b/src/modelscope_hub/_legacy_api.py
@@ -149,6 +149,7 @@ class LegacyClient:
         params: dict[str, Any] | None = None,
         json_body: Any | None = None,
         data: Any | None = None,
+        files: dict[str, Any] | None = None,
         headers: dict[str, str] | None = None,
         timeout: int | None = None,
         stream: bool = False,
@@ -157,8 +158,9 @@ class LegacyClient:
         self._ensure_session_auth()
         url = self._build_url(path)
         merged_headers = self._headers(headers)
-        # Remove Content-Type for non-json payloads
-        if data is not None and json_body is None:
+        # Remove Content-Type for non-json payloads so requests can set
+        # the correct boundary for multipart or the right encoding for data.
+        if (data is not None or files is not None) and json_body is None:
             merged_headers.pop("Content-Type", None)
 
         logger.debug("%s %s", method, url)
@@ -169,6 +171,7 @@ class LegacyClient:
                 params=params,
                 json=json_body,
                 data=data,
+                files=files,
                 headers=merged_headers,
                 timeout=timeout or self._timeout,
                 stream=stream,
@@ -215,9 +218,16 @@ class LegacyClient:
         """POST /api/v1/{type}s — create a new repository.
 
         ``body`` is the fully-constructed request payload (PascalCase keys).
+
+        The dataset endpoint requires multipart form data (matching the
+        upstream server implementation), while model uses JSON.
         """
         segment = _resolve_segment(repo_type)
-        resp = self._request("POST", segment, json_body=body)
+        if repo_type in (RepoType.DATASET, "dataset"):
+            files = {k: (None, str(v)) for k, v in body.items() if v is not None}
+            resp = self._request("POST", segment, files=files)
+        else:
+            resp = self._request("POST", segment, json_body=body)
         return self._json_data(resp)
 
     def delete_repo(self, repo_id: str, repo_type: str) -> None:

--- a/src/modelscope_hub/_legacy_api.py
+++ b/src/modelscope_hub/_legacy_api.py
@@ -182,6 +182,15 @@ class LegacyClient:
             raise RequestTimeoutError(f"Request timed out: {exc}") from exc
 
         logger.debug("%s %s -> %s", method, url, resp.status_code)
+        if resp.status_code >= 400:
+            logger.debug(
+                "Request failed: %s %s params=%s status=%s body=%s",
+                method,
+                url,
+                params,
+                resp.status_code,
+                resp.text[:500] if resp.text else "",
+            )
         raise_for_status(resp)
         return resp
 

--- a/src/modelscope_hub/_openapi.py
+++ b/src/modelscope_hub/_openapi.py
@@ -205,6 +205,15 @@ class OpenAPIClient:
                 last_exc = NetworkError(f"Request failed: {exc}")
             else:
                 _logger.debug("%s %s -> %s", method_upper, url, response.status_code)
+                if response.status_code >= 400:
+                    _logger.debug(
+                        "Request failed: %s %s params=%s status=%s body=%s",
+                        method_upper,
+                        url,
+                        params,
+                        response.status_code,
+                        response.text[:500] if response.text else "",
+                    )
                 try:
                     raise_for_status(response)
                 except _RETRYABLE_EXC as exc:  # type: ignore[misc]

--- a/src/modelscope_hub/api.py
+++ b/src/modelscope_hub/api.py
@@ -287,6 +287,20 @@ class HubApi:
         for key, value in data.items():
             normalised[aliases.get(key, key)] = value
 
+        # The OpenAPI surface encodes visibility as a ``private`` bool (with an
+        # optional ``gated`` flag) instead of the legacy ``Visibility`` integer.
+        # Translate it so downstream code sees a uniform ``Visibility`` enum.
+        if normalised.get("visibility") is None:
+            private_flag = normalised.pop("private", None)
+            gated_flag = normalised.pop("gated", None)
+            if isinstance(private_flag, bool):
+                if private_flag:
+                    normalised["visibility"] = Visibility.PRIVATE
+                elif gated_flag:
+                    normalised["visibility"] = Visibility.INTERNAL
+                else:
+                    normalised["visibility"] = Visibility.PUBLIC
+
         normalised.setdefault("owner", owner_hint)
         normalised.setdefault("name", name_hint)
         normalised["repo_type"] = repo_type

--- a/src/modelscope_hub/api.py
+++ b/src/modelscope_hub/api.py
@@ -85,6 +85,11 @@ _LICENSE_DISPLAY_TO_SPDX: dict[str, str] = {
 }
 
 
+_STUDIO_FIELD_RENAMES: dict[str, str] = {
+    "cover_image": "coverImage",
+}
+
+
 class HubApi:
     """Unified client for ModelScope Hub operations.
 
@@ -558,6 +563,9 @@ class HubApi:
                 payload["license"] = license
             if description is not None:
                 payload["description"] = description
+            for old_key, new_key in _STUDIO_FIELD_RENAMES.items():
+                if old_key in extra:
+                    extra[new_key] = extra.pop(old_key)
             payload.update(extra)
             data = (
                 self.openapi.create_studio(payload)
@@ -1506,6 +1514,9 @@ class HubApi:
         """
         rt = self._normalize_repo_type(repo_type)
         owner, name = self._parse_repo_id(repo_id)
+        for old_key, new_key in _STUDIO_FIELD_RENAMES.items():
+            if old_key in settings:
+                settings[new_key] = settings.pop(old_key)
         if rt is RepoType.STUDIO:
             return self.openapi.update_studio_settings(owner, name, settings)
         if rt is RepoType.SKILL:

--- a/src/modelscope_hub/api.py
+++ b/src/modelscope_hub/api.py
@@ -56,6 +56,9 @@ RepoTypeLike = "str | RepoType"
 
 # Routing tables — declarative dispatch keeps :class:`HubApi` free of long
 # if/elif chains and makes adding new repo types a one-line change.
+_CREATABLE_TYPES: frozenset[RepoType] = frozenset(
+    {RepoType.MODEL, RepoType.DATASET, RepoType.STUDIO, RepoType.SKILL}
+)
 _OPENAPI_CREATE_TYPES: frozenset[RepoType] = frozenset({RepoType.STUDIO, RepoType.SKILL})
 _OPENAPI_DETAIL_TYPES: frozenset[RepoType] = frozenset(
     {RepoType.MODEL, RepoType.DATASET, RepoType.STUDIO, RepoType.SKILL}
@@ -506,6 +509,12 @@ class HubApi:
         >>> api.create_repo("alice/chat-demo", repo_type="studio", visibility="public")
         """
         rt = self._normalize_repo_type(repo_type)
+        if rt not in _CREATABLE_TYPES:
+            supported = ", ".join(sorted(t.value for t in _CREATABLE_TYPES))
+            raise NotSupportedError(
+                f"create_repo does not support repo_type={rt.value!r}. "
+                f"Supported types: {supported}."
+            )
         owner, name = self._parse_repo_id(repo_id)
         vis = self._normalize_visibility(visibility)
         if license is not None:

--- a/src/modelscope_hub/api.py
+++ b/src/modelscope_hub/api.py
@@ -554,12 +554,20 @@ class HubApi:
                 data, rt, owner_hint=owner, name_hint=name
             )
 
-        body: dict[str, Any] = {
-            "Path": owner,
-            "Name": name,
-            "Visibility": vis if vis is not None else int(Visibility.PUBLIC),
-            "License": license or "Apache-2.0",
-        }
+        if rt is RepoType.DATASET:
+            body: dict[str, Any] = {
+                "Owner": owner,
+                "Name": name,
+                "Visibility": vis if vis is not None else int(Visibility.PUBLIC),
+                "License": license or "Apache-2.0",
+            }
+        else:
+            body = {
+                "Path": owner,
+                "Name": name,
+                "Visibility": vis if vis is not None else int(Visibility.PUBLIC),
+                "License": license or "Apache-2.0",
+            }
         if chinese_name is not None:
             body["ChineseName"] = chinese_name
         if description is not None:

--- a/src/modelscope_hub/api.py
+++ b/src/modelscope_hub/api.py
@@ -1085,6 +1085,12 @@ class HubApi:
         '{\n  "architectures": [\n    "Ll'
         """
         rt = self._normalize_repo_type(repo_type)
+        if rt is RepoType.STUDIO:
+            raise NotSupportedError(
+                "File download is not supported for studio repositories. "
+                "Studios are application containers without a file listing API. "
+                f"To access studio source code, use: git clone https://modelscope.cn/studios/{repo_id}.git"
+            )
         return self.downloader.download_file(
             repo_id=repo_id,
             repo_type=str(rt),
@@ -1159,6 +1165,12 @@ class HubApi:
         ['config.json', 'tokenizer.json', 'tokenizer_config.json']
         """
         rt = self._normalize_repo_type(repo_type)
+        if rt is RepoType.STUDIO:
+            raise NotSupportedError(
+                "File download is not supported for studio repositories. "
+                "Studios are application containers without a file listing API. "
+                f"To access studio source code, use: git clone https://modelscope.cn/studios/{repo_id}.git"
+            )
         return self.downloader.download_repo(
             repo_id=repo_id,
             repo_type=str(rt),

--- a/src/modelscope_hub/cli/base.py
+++ b/src/modelscope_hub/cli/base.py
@@ -44,7 +44,18 @@ class CLICommand(ABC):
 # Shared helpers
 # ---------------------------------------------------------------------------
 def make_api(args: Namespace) -> HubApi:
-    """Construct a :class:`HubApi` honouring global ``--token`` / ``--endpoint``."""
+    """Construct a :class:`HubApi` honouring global and subcommand ``--token`` / ``--endpoint``.
+
+    Automatically merges subcommand-level ``subcmd_token``/``subcmd_endpoint``
+    into the namespace (subcommand values take precedence over global values).
+    """
+    subcmd_token = getattr(args, "subcmd_token", None)
+    if subcmd_token:
+        args.token = subcmd_token
+    subcmd_endpoint = getattr(args, "subcmd_endpoint", None)
+    if subcmd_endpoint:
+        args.endpoint = subcmd_endpoint
+
     return HubApi(
         token=getattr(args, "token", None),
         endpoint=getattr(args, "endpoint", None),

--- a/src/modelscope_hub/cli/deploy.py
+++ b/src/modelscope_hub/cli/deploy.py
@@ -18,6 +18,7 @@ from .base import (
     parse_kv_pairs,
     success,
 )
+from .compat import add_subcmd_token_endpoint
 
 
 class DeployCommand(CLICommand):
@@ -33,6 +34,7 @@ class DeployCommand(CLICommand):
             default=RepoType.STUDIO.value,
             required=False,
         )
+        add_subcmd_token_endpoint(p)
         p.set_defaults(_command=DeployCommand)
 
     def execute(self) -> None:
@@ -54,6 +56,7 @@ class StopCommand(CLICommand):
             default=RepoType.STUDIO.value,
             required=False,
         )
+        add_subcmd_token_endpoint(p)
         p.set_defaults(_command=StopCommand)
 
     def execute(self) -> None:
@@ -79,6 +82,7 @@ class LogsCommand(CLICommand):
         p.add_argument("--page", "--page-num", dest="page_num", type=int, default=1)
         p.add_argument("--page-size", dest="page_size", type=int, default=100)
         p.add_argument("--keyword", default=None)
+        add_subcmd_token_endpoint(p)
         p.set_defaults(_command=LogsCommand)
 
     def execute(self) -> None:
@@ -117,6 +121,7 @@ class SettingsCommand(CLICommand):
             required=False,
         )
         p.add_argument("settings", nargs="+", help="One or more key=value pairs.")
+        add_subcmd_token_endpoint(p)
         p.set_defaults(_command=SettingsCommand)
 
     def execute(self) -> None:

--- a/src/modelscope_hub/cli/download.py
+++ b/src/modelscope_hub/cli/download.py
@@ -53,7 +53,7 @@ class DownloadCommand(CLICommand):
         )
         add_repo_type_arg(
             p,
-            choices=[RepoType.MODEL.value, RepoType.DATASET.value, RepoType.STUDIO.value],
+            choices=[RepoType.MODEL.value, RepoType.DATASET.value],
             default=RepoType.MODEL.value,
             required=False,
         )

--- a/src/modelscope_hub/cli/login.py
+++ b/src/modelscope_hub/cli/login.py
@@ -11,6 +11,7 @@ import getpass
 from argparse import Action, SUPPRESS
 
 from .base import CLICommand, error, info, make_api, success
+from .compat import add_subcmd_token_endpoint
 
 
 class LoginCommand(CLICommand):
@@ -65,6 +66,7 @@ class WhoamiCommand(CLICommand):
             "whoami",
             help="Show the user identified by the active token.",
         )
+        add_subcmd_token_endpoint(parser)
         parser.set_defaults(_command=WhoamiCommand)
 
     def execute(self) -> None:

--- a/src/modelscope_hub/cli/main.py
+++ b/src/modelscope_hub/cli/main.py
@@ -23,7 +23,7 @@ from .deploy import DeployCommand, LogsCommand, SettingsCommand, StopCommand
 from .download import DownloadCommand
 from .login import LoginCommand, WhoamiCommand
 from .mcp import McpCommand
-from .repo import RepoCommand, _RepoCreate
+from .repo import CreateCommand, DeleteCommand, InfoCommand, ListCommand, RepoCommand
 from .secret import SecretCommand
 from .upload import UploadCommand
 
@@ -32,7 +32,10 @@ from .upload import UploadCommand
 _COMMANDS = [
     LoginCommand,
     WhoamiCommand,
-    RepoCommand,
+    CreateCommand,
+    InfoCommand,
+    ListCommand,
+    DeleteCommand,
     DownloadCommand,
     UploadCommand,
     DeployCommand,
@@ -95,27 +98,9 @@ def _build_parser() -> argparse.ArgumentParser:
 # ---------------------------------------------------------------------------
 def _register_aliases(subparsers) -> None:
     """Register top-level command aliases for legacy CLI compatibility."""
-    _register_create_alias(subparsers)
+    RepoCommand.register(subparsers)
     _register_scan_cache_alias(subparsers)
     _register_clear_cache_alias(subparsers)
-
-
-def _register_create_alias(subparsers) -> None:
-    """``ms create`` → alias for ``ms repo create``."""
-    from ..constants import RepoType
-
-    p = subparsers.add_parser("create", help="[Alias] Create a new repository.")
-    p.add_argument("repo_id", help="Canonical 'owner/name' identifier.")
-    add_repo_type_arg(p)
-    p.add_argument("--visibility", choices=["public", "private", "internal"], default=None)
-    p.add_argument("--license", dest="license", default=None)
-    p.add_argument("--chinese-name", "--chinese_name", dest="chinese_name", default=None)
-    p.add_argument("--description", dest="description", default=None)
-    p.add_argument("--exist-ok", "--exist_ok", dest="exist_ok", action="store_true", default=False)
-    # Legacy hidden
-    p.add_argument("--token", dest="subcmd_token", default=None, help=SUPPRESS)
-    p.add_argument("--endpoint", dest="subcmd_endpoint", default=None, help=SUPPRESS)
-    p.set_defaults(_command=_CreateAlias)
 
 
 def _register_scan_cache_alias(subparsers) -> None:
@@ -137,19 +122,6 @@ def _register_clear_cache_alias(subparsers) -> None:
     p.add_argument("--yes", "-y", action="store_true", help="Skip confirmation.")
     p.set_defaults(_command=_ClearCacheAlias)
 
-
-class _CreateAlias(CLICommand):
-    """Adapter: top-level ``create`` → ``repo create``."""
-
-    @staticmethod
-    def register(subparsers) -> None:
-        pass  # registration handled by _register_create_alias
-
-    def execute(self) -> None:
-        from .compat import _merge_subcmd_auth
-        _merge_subcmd_auth(self.args, warn=False)
-        self.args.exist_ok = getattr(self.args, "exist_ok", False)
-        _RepoCreate(self.args).execute()
 
 
 class _ScanCacheAlias(CLICommand):

--- a/src/modelscope_hub/cli/mcp.py
+++ b/src/modelscope_hub/cli/mcp.py
@@ -6,6 +6,7 @@ import json
 from argparse import Action
 
 from .base import CLICommand, info, make_api, render_table, success
+from .compat import add_subcmd_token_endpoint
 
 
 class McpCommand(CLICommand):
@@ -38,6 +39,7 @@ class _McpList(CLICommand):
         p.add_argument("--search", default=None)
         p.add_argument("--page", dest="page_number", type=int, default=1)
         p.add_argument("--page-size", dest="page_size", type=int, default=20)
+        add_subcmd_token_endpoint(p)
         p.set_defaults(_command=McpCommand, _mcp_leaf=_McpList)
 
     def execute(self) -> None:
@@ -68,6 +70,7 @@ class _McpInfo(CLICommand):
     def register(subparsers: Action) -> None:
         p = subparsers.add_parser("info", help="Show details of an MCP server.")
         p.add_argument("server_id")
+        add_subcmd_token_endpoint(p)
         p.set_defaults(_command=McpCommand, _mcp_leaf=_McpInfo)
 
     def execute(self) -> None:
@@ -81,6 +84,7 @@ class _McpDeploy(CLICommand):
     def register(subparsers: Action) -> None:
         p = subparsers.add_parser("deploy", help="Deploy an MCP server.")
         p.add_argument("server_id")
+        add_subcmd_token_endpoint(p)
         p.set_defaults(_command=McpCommand, _mcp_leaf=_McpDeploy)
 
     def execute(self) -> None:
@@ -94,6 +98,7 @@ class _McpUndeploy(CLICommand):
     def register(subparsers: Action) -> None:
         p = subparsers.add_parser("undeploy", help="Undeploy an MCP server.")
         p.add_argument("server_id")
+        add_subcmd_token_endpoint(p)
         p.set_defaults(_command=McpCommand, _mcp_leaf=_McpUndeploy)
 
     def execute(self) -> None:

--- a/src/modelscope_hub/cli/repo.py
+++ b/src/modelscope_hub/cli/repo.py
@@ -70,7 +70,7 @@ class _RepoCreate(CLICommand):
     def register(subparsers: Action) -> None:
         p = subparsers.add_parser("create", help="Create a new repository.")
         p.add_argument("repo_id", help="Canonical 'owner/name' identifier.")
-        add_repo_type_arg(p)
+        add_repo_type_arg(p, choices=["model", "dataset", "studio", "skill"])
         p.add_argument("--visibility", choices=["public", "private", "internal"], default=None)
         p.add_argument("--license", dest="license", default=None)
         p.add_argument("--chinese-name", "--chinese_name", dest="chinese_name", default=None)

--- a/src/modelscope_hub/cli/repo.py
+++ b/src/modelscope_hub/cli/repo.py
@@ -1,4 +1,8 @@
-"""``ms repo`` group — create / info / delete / list."""
+"""Repository management commands: create / info / list / delete.
+
+These are registered as top-level commands (``ms create``, ``ms info``, etc.).
+The legacy ``ms repo <action>`` form is preserved as a hidden alias.
+"""
 
 from __future__ import annotations
 
@@ -7,36 +11,6 @@ from argparse import Action
 from ..constants import RepoType
 from ..types import RepoInfo
 from .base import CLICommand, add_repo_type_arg, info, make_api, render_table, success
-
-
-# ---------------------------------------------------------------------------
-# Group dispatcher
-# ---------------------------------------------------------------------------
-class RepoCommand(CLICommand):
-    """Top-level dispatcher for the ``repo`` subcommands."""
-
-    @staticmethod
-    def register(subparsers: Action) -> None:
-        parser = subparsers.add_parser(
-            "repo",
-            help="Manage repositories (model, dataset, studio, skill).",
-        )
-        sub = parser.add_subparsers(dest="repo_action", metavar="ACTION")
-        sub.required = True
-
-        _RepoCreate.register(sub)
-        _RepoInfo.register(sub)
-        _RepoDelete.register(sub)
-        _RepoList.register(sub)
-
-        parser.set_defaults(_command=RepoCommand)
-
-    def execute(self) -> None:
-        # Each leaf command sets its own ``_command`` via ``set_defaults``.
-        leaf = getattr(self.args, "_repo_leaf", None)
-        if leaf is None:  # pragma: no cover - argparse ensures coverage
-            raise SystemExit("No repo action given. See `ms repo --help`.")
-        leaf(self.args).execute()
 
 
 # ---------------------------------------------------------------------------
@@ -63,12 +37,19 @@ def _print_repo_info(repo: RepoInfo) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Leaf commands
+# Top-level commands
 # ---------------------------------------------------------------------------
-class _RepoCreate(CLICommand):
+class CreateCommand(CLICommand):
+    """``ms create`` — create a new repository."""
+
     @staticmethod
     def register(subparsers: Action) -> None:
         p = subparsers.add_parser("create", help="Create a new repository.")
+        CreateCommand._add_arguments(p)
+        p.set_defaults(_command=CreateCommand)
+
+    @staticmethod
+    def _add_arguments(p) -> None:
         p.add_argument("repo_id", help="Canonical 'owner/name' identifier.")
         add_repo_type_arg(p, choices=["model", "dataset", "studio", "skill"])
         p.add_argument("--visibility", choices=["public", "private", "internal"], default=None)
@@ -78,9 +59,6 @@ class _RepoCreate(CLICommand):
         p.add_argument("--exist-ok", "--exist_ok", dest="exist_ok",
                        action="store_true", default=False,
                        help="Do not error if repository already exists.")
-        # Studio-specific options. They are accepted for any repo type for a
-        # uniform CLI surface and forwarded as extra kwargs — the API layer
-        # only emits them for Studios.
         p.add_argument(
             "--sdk-type",
             dest="sdk_type",
@@ -92,7 +70,6 @@ class _RepoCreate(CLICommand):
         p.add_argument("--base-image", dest="base_image", default=None, help="Studio base image.")
         p.add_argument("--cover-image", dest="cover_image", default=None, help="Studio cover image URL.")
         p.add_argument("--hardware", dest="hardware", default=None, help="Studio hardware spec.")
-        p.set_defaults(_command=RepoCommand, _repo_leaf=_RepoCreate)
 
     def execute(self) -> None:
         api = make_api(self.args)
@@ -119,13 +96,19 @@ class _RepoCreate(CLICommand):
             raise
 
 
-class _RepoInfo(CLICommand):
+class InfoCommand(CLICommand):
+    """``ms info`` — show metadata for a repository."""
+
     @staticmethod
     def register(subparsers: Action) -> None:
         p = subparsers.add_parser("info", help="Show metadata for a repository.")
+        InfoCommand._add_arguments(p)
+        p.set_defaults(_command=InfoCommand)
+
+    @staticmethod
+    def _add_arguments(p) -> None:
         p.add_argument("repo_id")
         add_repo_type_arg(p)
-        p.set_defaults(_command=RepoCommand, _repo_leaf=_RepoInfo)
 
     def execute(self) -> None:
         api = make_api(self.args)
@@ -133,14 +116,20 @@ class _RepoInfo(CLICommand):
         _print_repo_info(repo)
 
 
-class _RepoDelete(CLICommand):
+class DeleteCommand(CLICommand):
+    """``ms delete`` — delete a repository."""
+
     @staticmethod
     def register(subparsers: Action) -> None:
         p = subparsers.add_parser("delete", help="Delete a repository (model or dataset).")
+        DeleteCommand._add_arguments(p)
+        p.set_defaults(_command=DeleteCommand)
+
+    @staticmethod
+    def _add_arguments(p) -> None:
         p.add_argument("repo_id")
         add_repo_type_arg(p, choices=[RepoType.MODEL.value, RepoType.DATASET.value])
         p.add_argument("--yes", "-y", action="store_true", help="Skip the confirmation prompt.")
-        p.set_defaults(_command=RepoCommand, _repo_leaf=_RepoDelete)
 
     def execute(self) -> None:
         if not self.args.yes:
@@ -155,10 +144,17 @@ class _RepoDelete(CLICommand):
         success(f"Deleted {self.args.repo_type}: {self.args.repo_id}")
 
 
-class _RepoList(CLICommand):
+class ListCommand(CLICommand):
+    """``ms list`` — list repositories of a given type."""
+
     @staticmethod
     def register(subparsers: Action) -> None:
         p = subparsers.add_parser("list", help="List repositories of a given type.")
+        ListCommand._add_arguments(p)
+        p.set_defaults(_command=ListCommand)
+
+    @staticmethod
+    def _add_arguments(p) -> None:
         add_repo_type_arg(
             p,
             choices=[
@@ -172,7 +168,6 @@ class _RepoList(CLICommand):
         p.add_argument("--search", default=None)
         p.add_argument("--page", dest="page_number", type=int, default=1)
         p.add_argument("--page-size", dest="page_size", type=int, default=10)
-        p.set_defaults(_command=RepoCommand, _repo_leaf=_RepoList)
 
     def execute(self) -> None:
         api = make_api(self.args)
@@ -201,3 +196,46 @@ class _RepoList(CLICommand):
             f"\npage {result.page_number} / total {result.total_count} "
             f"(page_size={result.page_size})"
         )
+
+
+# ---------------------------------------------------------------------------
+# Hidden backward-compat group: ``ms repo <action>``
+# ---------------------------------------------------------------------------
+class RepoCommand(CLICommand):
+    """Hidden compat dispatcher for ``ms repo create/info/list/delete``."""
+
+    @staticmethod
+    def register(subparsers: Action) -> None:
+        parser = subparsers.add_parser("repo")
+        # Hide from help by removing from the choices display
+        subparsers._choices_actions = [
+            a for a in subparsers._choices_actions if a.dest != "repo"
+        ]
+        sub = parser.add_subparsers(dest="repo_action", metavar="ACTION")
+        sub.required = True
+
+        # Re-register leaf commands under the "repo" group
+        p = sub.add_parser("create", help="Create a new repository.")
+        CreateCommand._add_arguments(p)
+        p.set_defaults(_command=CreateCommand)
+
+        p = sub.add_parser("info", help="Show metadata for a repository.")
+        InfoCommand._add_arguments(p)
+        p.set_defaults(_command=InfoCommand)
+
+        p = sub.add_parser("delete", help="Delete a repository.")
+        DeleteCommand._add_arguments(p)
+        p.set_defaults(_command=DeleteCommand)
+
+        p = sub.add_parser("list", help="List repositories.")
+        ListCommand._add_arguments(p)
+        p.set_defaults(_command=ListCommand)
+
+        parser.set_defaults(_command=RepoCommand)
+
+    def execute(self) -> None:
+        pass  # pragma: no cover - argparse dispatches to leaf _command
+
+
+# Backward-compat alias used by main.py's _CreateAlias
+_RepoCreate = CreateCommand

--- a/src/modelscope_hub/cli/repo.py
+++ b/src/modelscope_hub/cli/repo.py
@@ -212,9 +212,7 @@ class RepoCommand(CLICommand):
     @staticmethod
     def register(subparsers: Action) -> None:
         parser = subparsers.add_parser("repo")
-        # Hide from help output. _choices_actions is not public API but is the
-        # only reliable way to suppress a subparser from --help across Python
-        # versions (help=SUPPRESS renders as ==SUPPRESS== in 3.13+).
+
         try:
             subparsers._choices_actions = [
                 a for a in subparsers._choices_actions if a.dest != "repo"

--- a/src/modelscope_hub/cli/repo.py
+++ b/src/modelscope_hub/cli/repo.py
@@ -212,10 +212,15 @@ class RepoCommand(CLICommand):
     @staticmethod
     def register(subparsers: Action) -> None:
         parser = subparsers.add_parser("repo")
-        # Hide from help by removing from the choices display
-        subparsers._choices_actions = [
-            a for a in subparsers._choices_actions if a.dest != "repo"
-        ]
+        # Hide from help output. _choices_actions is not public API but is the
+        # only reliable way to suppress a subparser from --help across Python
+        # versions (help=SUPPRESS renders as ==SUPPRESS== in 3.13+).
+        try:
+            subparsers._choices_actions = [
+                a for a in subparsers._choices_actions if a.dest != "repo"
+            ]
+        except AttributeError:
+            pass
         sub = parser.add_subparsers(dest="repo_action", metavar="ACTION")
         sub.required = True
 

--- a/src/modelscope_hub/cli/repo.py
+++ b/src/modelscope_hub/cli/repo.py
@@ -11,6 +11,7 @@ from argparse import Action
 from ..constants import RepoType
 from ..types import RepoInfo
 from .base import CLICommand, add_repo_type_arg, info, make_api, render_table, success
+from .compat import add_subcmd_token_endpoint
 
 
 # ---------------------------------------------------------------------------
@@ -70,6 +71,7 @@ class CreateCommand(CLICommand):
         p.add_argument("--base-image", dest="base_image", default=None, help="Studio base image.")
         p.add_argument("--cover-image", dest="cover_image", default=None, help="Studio cover image URL.")
         p.add_argument("--hardware", dest="hardware", default=None, help="Studio hardware spec.")
+        add_subcmd_token_endpoint(p)
 
     def execute(self) -> None:
         api = make_api(self.args)
@@ -109,6 +111,7 @@ class InfoCommand(CLICommand):
     def _add_arguments(p) -> None:
         p.add_argument("repo_id")
         add_repo_type_arg(p)
+        add_subcmd_token_endpoint(p)
 
     def execute(self) -> None:
         api = make_api(self.args)
@@ -130,6 +133,7 @@ class DeleteCommand(CLICommand):
         p.add_argument("repo_id")
         add_repo_type_arg(p, choices=[RepoType.MODEL.value, RepoType.DATASET.value])
         p.add_argument("--yes", "-y", action="store_true", help="Skip the confirmation prompt.")
+        add_subcmd_token_endpoint(p)
 
     def execute(self) -> None:
         if not self.args.yes:
@@ -168,6 +172,7 @@ class ListCommand(CLICommand):
         p.add_argument("--search", default=None)
         p.add_argument("--page", dest="page_number", type=int, default=1)
         p.add_argument("--page-size", dest="page_size", type=int, default=10)
+        add_subcmd_token_endpoint(p)
 
     def execute(self) -> None:
         api = make_api(self.args)

--- a/src/modelscope_hub/cli/secret.py
+++ b/src/modelscope_hub/cli/secret.py
@@ -6,6 +6,7 @@ from argparse import Action
 
 from ..constants import RepoType
 from .base import CLICommand, add_repo_type_arg, info, make_api, render_table, success
+from .compat import add_subcmd_token_endpoint
 
 
 class SecretCommand(CLICommand):
@@ -46,6 +47,7 @@ class _SecretList(CLICommand):
         p = subparsers.add_parser("list", help="List secrets of a studio space.")
         p.add_argument("repo_id")
         _add_studio_repo_type(p)
+        add_subcmd_token_endpoint(p)
         p.set_defaults(_command=SecretCommand, _secret_leaf=_SecretList)
 
     def execute(self) -> None:
@@ -73,6 +75,7 @@ class _SecretAdd(CLICommand):
         p.add_argument("key")
         p.add_argument("value")
         _add_studio_repo_type(p)
+        add_subcmd_token_endpoint(p)
         p.set_defaults(_command=SecretCommand, _secret_leaf=_SecretAdd)
 
     def execute(self) -> None:
@@ -89,6 +92,7 @@ class _SecretUpdate(CLICommand):
         p.add_argument("key")
         p.add_argument("value")
         _add_studio_repo_type(p)
+        add_subcmd_token_endpoint(p)
         p.set_defaults(_command=SecretCommand, _secret_leaf=_SecretUpdate)
 
     def execute(self) -> None:
@@ -105,6 +109,7 @@ class _SecretDelete(CLICommand):
         p.add_argument("key")
         _add_studio_repo_type(p)
         p.add_argument("--yes", "-y", action="store_true")
+        add_subcmd_token_endpoint(p)
         p.set_defaults(_command=SecretCommand, _secret_leaf=_SecretDelete)
 
     def execute(self) -> None:

--- a/src/modelscope_hub/cli/upload.py
+++ b/src/modelscope_hub/cli/upload.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from ..constants import RepoType
 from .base import CLICommand, add_repo_type_arg, error, info, make_api, success
-from .compat import PatternAction, add_subcmd_token_endpoint, _merge_subcmd_auth
+from .compat import PatternAction, add_subcmd_token_endpoint
 
 
 class UploadCommand(CLICommand):
@@ -98,7 +98,6 @@ class UploadCommand(CLICommand):
         p.set_defaults(_command=UploadCommand)
 
     def execute(self) -> None:
-        _merge_subcmd_auth(self.args)
         api = make_api(self.args)
 
         local_path, path_in_repo = self._resolve_paths()

--- a/src/modelscope_hub/errors.py
+++ b/src/modelscope_hub/errors.py
@@ -155,7 +155,10 @@ class NotExistError(APIError):
 
     error_code = "E3020"
     retryable = False
-    suggestion = "The requested resource does not exist or has been deleted."
+    suggestion = (
+        "The requested resource does not exist, or it is private and requires "
+        "authentication. Use `ms login` or pass --token to authenticate."
+    )
 
 
 class InvalidParameter(APIError, ValueError):

--- a/src/modelscope_hub/errors.py
+++ b/src/modelscope_hub/errors.py
@@ -266,6 +266,7 @@ _STATUS_MAP: dict[int, type[APIError]] = {
     401: AuthenticationError,
     403: PermissionDeniedError,
     404: NotExistError,
+    405: InvalidParameter,
     429: RateLimitError,
 }
 
@@ -274,7 +275,14 @@ def _extract_payload(response: "Response") -> tuple[str, str | None, Any | None]
     """Best-effort extraction of (message, request_id, body) from a response."""
     request_id = response.headers.get("x-request-id") or response.headers.get("X-Request-Id")
     body: Any | None = None
-    message = f"HTTP {response.status_code}"
+
+    # Build a contextual fallback message that includes request method/path
+    req = response.request
+    if req and req.method and req.path_url:
+        message = f"HTTP {response.status_code} on {req.method} {req.path_url}"
+    else:
+        message = f"HTTP {response.status_code}"
+
     try:
         body = response.json()
     except ValueError:

--- a/src/modelscope_hub/errors.py
+++ b/src/modelscope_hub/errors.py
@@ -84,12 +84,36 @@ class APIError(HubError):
         parts.append(self.message)
         if self.request_id:
             parts.append(f"(request_id={self.request_id})")
-        if self.response_body is not None and self.message.startswith("HTTP "):
+        detail = self._format_body_detail()
+        if detail:
+            parts.append(f"| {detail}")
+        return " ".join(parts)
+
+    def _format_body_detail(self) -> str | None:
+        """Extract additional detail from response_body not already in message."""
+        if self.response_body is None:
+            return None
+        if isinstance(self.response_body, dict):
+            extras: list[str] = []
+            code = self.response_body.get("Code") or self.response_body.get("code")
+            if code is not None:
+                extras.append(f"code={code}")
+            for key in ("Data", "data", "detail", "Detail", "errors"):
+                val = self.response_body.get(key)
+                if val is not None:
+                    val_str = str(val)
+                    if len(val_str) > 300:
+                        val_str = val_str[:300] + "..."
+                    extras.append(f"{key}={val_str}")
+            if extras:
+                return ", ".join(extras)
+            return None
+        if self.message.startswith("HTTP "):
             body_str = str(self.response_body)
             if len(body_str) > 500:
                 body_str = body_str[:500] + "..."
-            parts.append(f"| body={body_str}")
-        return " ".join(parts)
+            return f"body={body_str}"
+        return None
 
 
 # -- Auth / Permission (E3001, E3002) --------------------------------------

--- a/src/modelscope_hub/errors.py
+++ b/src/modelscope_hub/errors.py
@@ -69,11 +69,15 @@ class APIError(HubError):
         status_code: int | None = None,
         request_id: str | None = None,
         response_body: Any | None = None,
+        url: str | None = None,
+        method: str | None = None,
     ) -> None:
         super().__init__(message)
         self.status_code = status_code
         self.request_id = request_id
         self.response_body = response_body
+        self.url = url
+        self.method = method
 
     def __str__(self) -> str:
         parts: list[str] = []
@@ -87,7 +91,19 @@ class APIError(HubError):
         detail = self._format_body_detail()
         if detail:
             parts.append(f"| {detail}")
-        return " ".join(parts)
+        # Append debug context on separate lines
+        headline = " ".join(parts)
+        debug_lines: list[str] = []
+        if self.url:
+            debug_lines.append(f"  Request: {self.method or 'GET'} {self.url}")
+        if self.response_body is not None:
+            body_str = str(self.response_body)
+            if len(body_str) > 500:
+                body_str = body_str[:500] + "..."
+            debug_lines.append(f"  Response: {body_str}")
+        if debug_lines:
+            return headline + "\n" + "\n".join(debug_lines)
+        return headline
 
     def _format_body_detail(self) -> str | None:
         """Extract additional detail from response_body not already in message."""
@@ -169,6 +185,8 @@ class RateLimitError(APIError):
         status_code: int | None = 429,
         request_id: str | None = None,
         response_body: Any | None = None,
+        url: str | None = None,
+        method: str | None = None,
         retry_after: int | float | None = None,
     ) -> None:
         super().__init__(
@@ -176,6 +194,8 @@ class RateLimitError(APIError):
             status_code=status_code,
             request_id=request_id,
             response_body=response_body,
+            url=url,
+            method=method,
         )
         self.retry_after = retry_after
 
@@ -347,6 +367,11 @@ def raise_for_status(response: "Response") -> None:
 
     message, request_id, body = _extract_payload(response)
 
+    # Extract request URL and method for debug context
+    req = response.request
+    url: str | None = response.url or (req.url if req else None)
+    method: str | None = req.method if req else None
+
     if status >= 500:
         exc_cls: type[APIError] = ServerError
     else:
@@ -356,6 +381,8 @@ def raise_for_status(response: "Response") -> None:
         status_code=status,
         request_id=request_id,
         response_body=body,
+        url=url,
+        method=method,
     )
 
     if exc_cls is RateLimitError:

--- a/src/modelscope_hub/types.py
+++ b/src/modelscope_hub/types.py
@@ -232,7 +232,7 @@ class CreateStudioPayload(TypedDict, total=False):
     license: str
     private: bool
     description: str
-    cover_image: str
+    coverImage: str
     sdk_type: str
     sdk_version: str
     base_image: str
@@ -246,7 +246,7 @@ class UpdateStudioSettingsPayload(TypedDict, total=False):
     license: str
     private: bool
     description: str
-    cover_image: str
+    coverImage: str
     sdk_type: str
     sdk_version: str
     base_image: str

--- a/src/modelscope_hub/version.py
+++ b/src/modelscope_hub/version.py
@@ -1,3 +1,3 @@
 """Version information for modelscope_hub."""
 
-__version__ = "0.0.3+main"
+__version__ = "0.0.4+main"

--- a/tests/.env.example
+++ b/tests/.env.example
@@ -2,3 +2,6 @@
 MODELSCOPE_TEST_TOKEN=your_token_here
 MODELSCOPE_TEST_OWNER=your_username_here
 MODELSCOPE_TEST_ENDPOINT=https://modelscope.cn
+
+# Set to true to run @pytest.mark.remote tests (requires valid token/owner above)
+MODELSCOPE_RUN_REMOTE_TESTS=true

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,19 +1,84 @@
-"""CLI test fixtures for real API integration tests."""
+"""CLI test fixtures — shared across unit and remote integration tests."""
 from __future__ import annotations
 
 import io
-import os
 import sys
 import uuid
+from unittest.mock import MagicMock
 
 import pytest
 
 from modelscope_hub.api import HubApi
-from modelscope_hub.cli.main import run_cmd
+from modelscope_hub.cli.main import _build_parser, run_cmd
+from modelscope_hub.types import CacheInfo, CachedRepoInfo, PagedResult, RepoInfo, UserInfo
 
 
 # ---------------------------------------------------------------------------
-# Real API fixtures
+# Shared parser fixture (used by ALL parser tests)
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def parser():
+    """Build the full CLI parser for argument-parsing tests."""
+    return _build_parser()
+
+
+# ---------------------------------------------------------------------------
+# Mock API fixture for unit-level execution tests
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def mock_api():
+    """Return a ``MagicMock`` mimicking :class:`HubApi`.
+
+    Common return values are pre-configured so tests don't need to repeat
+    boilerplate. Override specific methods in individual tests as needed.
+    """
+    api = MagicMock(spec=HubApi)
+    api.create_repo.return_value = RepoInfo(
+        id=1, owner="owner", name="repo", repo_type="model",
+    )
+    api.get_repo.return_value = RepoInfo(
+        id=1, owner="owner", name="repo", repo_type="model",
+        visibility=None, license="apache-2.0", downloads=100, likes=5,
+    )
+    api.list_repos.return_value = PagedResult(
+        items=[
+            RepoInfo(id=1, owner="owner", name="model1", repo_type="model",
+                     visibility=None, downloads=100, likes=5),
+        ],
+        total_count=1, page_number=1, page_size=10,
+    )
+    api.download_file.return_value = "/cache/owner/repo/file.txt"
+    api.download_repo.return_value = "/cache/owner/repo"
+    api.upload_folder.return_value = "commit_sha"
+    api.whoami.return_value = UserInfo(
+        username="testuser", email="test@example.com", id=42, description="",
+    )
+    api.login.return_value = UserInfo(
+        username="testuser", email="test@example.com", id=42,
+    )
+    api.scan_cache.return_value = CacheInfo(
+        cache_dir="/tmp/cache", total_size=1024,
+        repos=[CachedRepoInfo(
+            repo_id="owner/repo", repo_type="model", revision="master",
+            nb_files=3, size_on_disk=1024, local_path="/tmp/cache/owner/repo",
+        )],
+    )
+    api.clear_cache.return_value = 2048
+    api.list_secrets.return_value = [
+        {"key": "API_KEY", "description": "test", "updated_at": "2000-01-01T00:00:00Z"},
+    ]
+    api.list_mcp_servers.return_value = PagedResult(
+        items=[{"id": "mcp-1", "name": "weather", "status": "running", "description": "Weather MCP"}],
+        total_count=1, page_number=1, page_size=20,
+    )
+    api.get_mcp_server.return_value = {"id": "mcp-1", "name": "weather"}
+    api.get_repo_logs.return_value = {"logs": ["line1", "line2"]}
+    api.resolve_endpoint_for_read.return_value = "https://modelscope.cn"
+    return api
+
+
+# ---------------------------------------------------------------------------
+# Real API fixtures (used by @pytest.mark.remote tests)
 # ---------------------------------------------------------------------------
 @pytest.fixture(scope="class")
 def api(test_token, test_endpoint) -> HubApi:

--- a/tests/cli/run_all.py
+++ b/tests/cli/run_all.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Run all CLI unit tests (no network / API credentials required).
+
+Usage:
+    python tests/cli/run_all.py          # from project root
+    python -m tests.cli.run_all          # as module
+    make test-cli                        # via Makefile
+
+This script discovers and runs every ``test_*.py`` under ``tests/cli/``,
+excluding tests marked ``@pytest.mark.remote`` which require live API access.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_TESTS_DIR = Path(__file__).resolve().parent
+_PROJECT_ROOT = _TESTS_DIR.parent.parent
+
+
+def main() -> int:
+    cmd = [
+        sys.executable, "-m", "pytest",
+        str(_TESTS_DIR),
+        "-k", "not remote",
+        "-v",
+        "--tb=short",
+    ]
+    print(f"Running: {' '.join(cmd)}")
+    return subprocess.call(cmd, cwd=str(_PROJECT_ROOT))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/cli/run_all.py
+++ b/tests/cli/run_all.py
@@ -23,7 +23,6 @@ def main() -> int:
     cmd = [
         sys.executable, "-m", "pytest",
         str(_TESTS_DIR),
-        "-k", "not remote",
         "-v",
         "--tb=short",
     ]

--- a/tests/cli/test_cache.py
+++ b/tests/cli/test_cache.py
@@ -204,6 +204,14 @@ class TestCacheClearExecute:
         assert kw["repo_type"] == "model"
         assert kw["repo_id"] == "owner/repo"
 
+    def test_clear_cache_dir_forwarded(self, parser, mock_api, capsys):
+        args = parser.parse_args([
+            "cache", "clear", "--cache-dir", "/data", "--yes",
+        ])
+        with patch("modelscope_hub.cli.cache.make_api", return_value=mock_api):
+            _CacheClear(args).execute()
+        assert mock_api.clear_cache.call_args.kwargs["cache_dir"] == "/data"
+
 
 # ===================================================================
 # Remote integration tests (existing)

--- a/tests/cli/test_cache.py
+++ b/tests/cli/test_cache.py
@@ -123,6 +123,7 @@ class TestCacheLegacyAliases:
 # ===================================================================
 # Execution tests — mock HubApi
 # ===================================================================
+@pytest.mark.mock_only
 class TestCacheScanExecute:
     """_CacheScan.execute() logic."""
 
@@ -152,6 +153,7 @@ class TestCacheScanExecute:
         assert "0 repo(s)" in out
 
 
+@pytest.mark.mock_only
 class TestCacheClearExecute:
     """_CacheClear.execute() logic."""
 

--- a/tests/cli/test_cache.py
+++ b/tests/cli/test_cache.py
@@ -1,14 +1,213 @@
-"""Tests for ``ms cache`` group — real API download + local cache operations."""
+"""Tests for ``ms cache`` group — scan and clear.
+
+Includes:
+- Parser tests: all flags and subcommands
+- Execution tests: mock HubApi for scan/clear logic
+- Legacy alias tests: scan-cache, clear-cache
+- Remote tests: real API cache lifecycle (existing)
+"""
 from __future__ import annotations
 
 import base64
 import warnings
+from unittest.mock import patch
 
 import pytest
+
+from modelscope_hub.cli.cache import CacheCommand, _CacheClear, _CacheScan
+from modelscope_hub.types import CacheInfo
 
 from .conftest import run_cli
 
 
+# ===================================================================
+# Parser tests
+# ===================================================================
+class TestCacheScanParser:
+    """``ms cache scan`` argument parsing."""
+
+    def test_basic(self, parser):
+        args = parser.parse_args(["cache", "scan"])
+        assert hasattr(args, "_cache_leaf")
+
+    def test_cache_dir(self, parser):
+        args = parser.parse_args(["cache", "scan", "--cache-dir", "/data/cache"])
+        assert args.cache_dir == "/data/cache"
+
+    def test_cache_dir_default_none(self, parser):
+        args = parser.parse_args(["cache", "scan"])
+        assert args.cache_dir is None
+
+
+class TestCacheClearParser:
+    """``ms cache clear`` argument parsing."""
+
+    def test_basic_with_yes(self, parser):
+        args = parser.parse_args(["cache", "clear", "--yes"])
+        assert args.yes is True
+
+    def test_repo_type(self, parser):
+        args = parser.parse_args([
+            "cache", "clear", "--repo-type", "model", "--yes",
+        ])
+        assert args.repo_type == "model"
+
+    @pytest.mark.parametrize("repo_type", ["model", "dataset", "studio", "skill", "mcp"])
+    def test_all_repo_types(self, parser, repo_type):
+        args = parser.parse_args([
+            "cache", "clear", "--repo-type", repo_type, "--yes",
+        ])
+        assert args.repo_type == repo_type
+
+    def test_repo_id(self, parser):
+        args = parser.parse_args([
+            "cache", "clear",
+            "--repo-type", "model", "--repo-id", "owner/model1",
+            "--yes",
+        ])
+        assert args.repo_id == "owner/model1"
+
+    def test_cache_dir(self, parser):
+        args = parser.parse_args([
+            "cache", "clear", "--cache-dir", "/data/cache", "--yes",
+        ])
+        assert args.cache_dir == "/data/cache"
+
+    def test_yes_short_flag(self, parser):
+        args = parser.parse_args(["cache", "clear", "-y"])
+        assert args.yes is True
+
+    def test_yes_default_false(self, parser):
+        args = parser.parse_args(["cache", "clear"])
+        assert args.yes is False
+
+
+class TestCacheLegacyAliases:
+    """Legacy ``ms scan-cache`` / ``ms clear-cache`` aliases."""
+
+    def test_scan_cache_alias(self, parser):
+        args = parser.parse_args(["scan-cache"])
+        assert hasattr(args, "_command")
+
+    def test_scan_cache_with_cache_dir(self, parser):
+        args = parser.parse_args(["scan-cache", "--cache-dir", "/data"])
+        assert args.cache_dir == "/data"
+
+    def test_scan_cache_with_dir_alias(self, parser):
+        args = parser.parse_args(["scan-cache", "--dir", "/data"])
+        assert args.cache_dir == "/data"
+
+    def test_clear_cache_model(self, parser):
+        args = parser.parse_args(["clear-cache", "--model", "owner/repo"])
+        assert args.model == "owner/repo"
+
+    def test_clear_cache_dataset(self, parser):
+        args = parser.parse_args(["clear-cache", "--dataset", "owner/data"])
+        assert args.dataset == "owner/data"
+
+    def test_clear_cache_with_cache_dir(self, parser):
+        args = parser.parse_args([
+            "clear-cache", "--model", "owner/repo", "--cache-dir", "/tmp",
+        ])
+        assert args.cache_dir == "/tmp"
+
+    def test_clear_cache_yes_flag(self, parser):
+        args = parser.parse_args(["clear-cache", "--model", "o/r", "--yes"])
+        assert args.yes is True
+
+    def test_clear_cache_model_dataset_mutually_exclusive(self, parser):
+        with pytest.raises(SystemExit):
+            parser.parse_args(["clear-cache", "--model", "a", "--dataset", "b"])
+
+
+# ===================================================================
+# Execution tests — mock HubApi
+# ===================================================================
+class TestCacheScanExecute:
+    """_CacheScan.execute() logic."""
+
+    def test_scan_with_repos(self, parser, mock_api, capsys):
+        args = parser.parse_args(["cache", "scan"])
+        with patch("modelscope_hub.cli.cache.make_api", return_value=mock_api):
+            _CacheScan(args).execute()
+        mock_api.scan_cache.assert_called_once_with(None)
+        out = capsys.readouterr().out
+        assert "1 repo(s)" in out
+        assert "owner/repo" in out
+
+    def test_scan_with_cache_dir(self, parser, mock_api, capsys):
+        args = parser.parse_args(["cache", "scan", "--cache-dir", "/data"])
+        with patch("modelscope_hub.cli.cache.make_api", return_value=mock_api):
+            _CacheScan(args).execute()
+        mock_api.scan_cache.assert_called_once_with("/data")
+
+    def test_scan_empty(self, parser, mock_api, capsys):
+        mock_api.scan_cache.return_value = CacheInfo(
+            cache_dir="/tmp/cache", total_size=0, repos=[],
+        )
+        args = parser.parse_args(["cache", "scan"])
+        with patch("modelscope_hub.cli.cache.make_api", return_value=mock_api):
+            _CacheScan(args).execute()
+        out = capsys.readouterr().out
+        assert "0 repo(s)" in out
+
+
+class TestCacheClearExecute:
+    """_CacheClear.execute() logic."""
+
+    def test_clear_with_yes(self, parser, mock_api, capsys):
+        args = parser.parse_args([
+            "cache", "clear", "--repo-type", "model", "--yes",
+        ])
+        with patch("modelscope_hub.cli.cache.make_api", return_value=mock_api):
+            _CacheClear(args).execute()
+        mock_api.clear_cache.assert_called_once()
+        out = capsys.readouterr().out
+        assert "Freed" in out
+
+    def test_clear_aborted(self, parser, mock_api, capsys):
+        args = parser.parse_args(["cache", "clear"])
+        with (
+            patch("modelscope_hub.cli.cache.make_api", return_value=mock_api),
+            patch("builtins.input", return_value="n"),
+        ):
+            _CacheClear(args).execute()
+        mock_api.clear_cache.assert_not_called()
+        out = capsys.readouterr().out
+        assert "Aborted" in out
+
+    def test_clear_confirmed_interactively(self, parser, mock_api, capsys):
+        args = parser.parse_args(["cache", "clear"])
+        with (
+            patch("modelscope_hub.cli.cache.make_api", return_value=mock_api),
+            patch("builtins.input", return_value="yes"),
+        ):
+            _CacheClear(args).execute()
+        mock_api.clear_cache.assert_called_once()
+
+    def test_clear_repo_id_without_type_exits(self, parser, mock_api, capsys):
+        args = parser.parse_args(["cache", "clear", "--repo-id", "o/r", "--yes"])
+        with patch("modelscope_hub.cli.cache.make_api", return_value=mock_api):
+            with pytest.raises(SystemExit) as exc_info:
+                _CacheClear(args).execute()
+            assert exc_info.value.code == 2
+
+    def test_clear_specific_repo(self, parser, mock_api, capsys):
+        args = parser.parse_args([
+            "cache", "clear",
+            "--repo-type", "model", "--repo-id", "owner/repo",
+            "--yes",
+        ])
+        with patch("modelscope_hub.cli.cache.make_api", return_value=mock_api):
+            _CacheClear(args).execute()
+        kw = mock_api.clear_cache.call_args.kwargs
+        assert kw["repo_type"] == "model"
+        assert kw["repo_id"] == "owner/repo"
+
+
+# ===================================================================
+# Remote integration tests (existing)
+# ===================================================================
 @pytest.mark.remote
 class TestCacheLifecycle:
     """Download a file to populate the cache, then scan and clear it.

--- a/tests/cli/test_compat.py
+++ b/tests/cli/test_compat.py
@@ -1,7 +1,8 @@
 """Unit tests for CLI backward compatibility.
 
-These tests verify that the argparse layer accepts both legacy and new-style
-arguments without making any remote API calls.
+Tests the normalization layer (normalize_download_args, normalize_patterns)
+and edge cases in legacy argument handling. Per-command parser and execution
+tests live in their respective ``test_<command>.py`` files.
 """
 
 from __future__ import annotations
@@ -10,86 +11,21 @@ import warnings
 
 import pytest
 
-from modelscope_hub.cli.main import _build_parser
 from modelscope_hub.cli.compat import normalize_download_args, normalize_patterns
 
 
 # ---------------------------------------------------------------------------
-# Parser fixture
+# Download: legacy argument edge cases
 # ---------------------------------------------------------------------------
-@pytest.fixture
-def parser():
-    return _build_parser()
-
-
-# ---------------------------------------------------------------------------
-# Download: legacy argument styles
-# ---------------------------------------------------------------------------
-class TestDownloadLegacyArgs:
-    def test_legacy_model_flag(self, parser):
-        """ms download --model owner/repo"""
-        args = parser.parse_args(["download", "--model", "owner/repo"])
-        assert args.model == "owner/repo"
-
-    def test_legacy_dataset_flag(self, parser):
-        """ms download --dataset owner/repo"""
-        args = parser.parse_args(["download", "--dataset", "owner/repo"])
-        assert args.dataset == "owner/repo"
-
-    def test_legacy_local_dir_underscore(self, parser):
-        """ms download --model owner/repo --local_dir ./tmp"""
-        args = parser.parse_args([
-            "download", "--model", "owner/repo", "--local_dir", "./tmp"
-        ])
-        assert args.local_dir_legacy == "./tmp"
-
-    def test_legacy_cache_dir_underscore(self, parser):
-        """ms download --model owner/repo --cache_dir /cache"""
-        args = parser.parse_args([
-            "download", "--model", "owner/repo", "--cache_dir", "/cache"
-        ])
-        assert args.cache_dir_legacy == "/cache"
-
-    def test_new_style_positional(self, parser):
-        """ms download owner/repo --repo-type dataset --local-dir ./tmp"""
-        args = parser.parse_args([
-            "download", "owner/repo", "--repo-type", "dataset",
-            "--local-dir", "./tmp",
-        ])
-        assert args.repo_id == "owner/repo"
-        assert args.repo_type == "dataset"
-        assert args.local_dir == "./tmp"
-
-    def test_new_style_with_files(self, parser):
-        """ms download owner/repo file1.bin file2.bin"""
-        args = parser.parse_args(["download", "owner/repo", "file1.bin", "file2.bin"])
-        assert args.repo_id == "owner/repo"
-        assert args.files == ["file1.bin", "file2.bin"]
-
+class TestDownloadLegacyEdgeCases:
     def test_legacy_dataset_with_local_dir(self, parser):
-        """ms download --dataset owner/repo --local_dir ./temp (the user's failing command)"""
+        """ms download --dataset owner/repo --local_dir ./temp (regression test)"""
         args = parser.parse_args([
             "download", "--dataset", "wangxingjun778/self_cog_data",
             "--local_dir", "./temp",
         ])
         assert args.dataset == "wangxingjun778/self_cog_data"
         assert args.local_dir_legacy == "./temp"
-
-    def test_repo_type_underscore(self, parser):
-        """ms download owner/repo --repo_type dataset"""
-        args = parser.parse_args([
-            "download", "owner/repo", "--repo_type", "dataset",
-        ])
-        assert args.repo_type == "dataset"
-
-    def test_subcmd_token_endpoint(self, parser):
-        """Legacy per-subcommand --token/--endpoint are accepted."""
-        args = parser.parse_args([
-            "download", "--model", "owner/repo",
-            "--token", "ms-xxx", "--endpoint", "https://custom.cn",
-        ])
-        assert args.subcmd_token == "ms-xxx"
-        assert args.subcmd_endpoint == "https://custom.cn"
 
 
 # ---------------------------------------------------------------------------
@@ -127,7 +63,7 @@ class TestNormalizeDownloadArgs:
             normalize_download_args(args)
 
     def test_model_with_positional_becomes_file(self, parser):
-        """ms download --model owner/repo file.bin → file.bin is a file to download."""
+        """ms download --model owner/repo file.bin -> file.bin is a file to download."""
         args = parser.parse_args(["download", "file.bin", "--model", "owner/repo"])
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
@@ -154,133 +90,42 @@ class TestNormalizeDownloadArgs:
 
 
 # ---------------------------------------------------------------------------
-# Include/Exclude patterns
+# Include/Exclude patterns — normalize_patterns function
 # ---------------------------------------------------------------------------
-class TestPatternAction:
-    def test_multi_value(self, parser):
-        """--include a b c"""
-        args = parser.parse_args(["download", "owner/repo", "--include", "*.bin", "*.json"])
-        assert args.allow_patterns == ["*.bin", "*.json"]
-
-    def test_repeated(self, parser):
-        """--include a --include b"""
-        args = parser.parse_args([
-            "download", "owner/repo", "--include", "*.bin", "--include", "*.json"
-        ])
-        assert "*.bin" in args.allow_patterns
-        assert "*.json" in args.allow_patterns
-
-    def test_normalize_patterns_none(self):
+class TestNormalizePatterns:
+    def test_none(self):
         assert normalize_patterns(None) is None
 
-    def test_normalize_patterns_string(self):
+    def test_string(self):
         assert normalize_patterns("*.bin") == ["*.bin"]
 
-    def test_normalize_patterns_flat_list(self):
+    def test_flat_list(self):
         assert normalize_patterns(["a", "b"]) == ["a", "b"]
 
-    def test_normalize_patterns_nested(self):
+    def test_nested(self):
         assert normalize_patterns([["a", "b"], "c"]) == ["a", "b", "c"]
 
 
 # ---------------------------------------------------------------------------
-# Top-level aliases
-# ---------------------------------------------------------------------------
-class TestAliases:
-    def test_scan_cache_alias(self, parser):
-        args = parser.parse_args(["scan-cache"])
-        assert hasattr(args, "_command")
-
-    def test_clear_cache_alias(self, parser):
-        args = parser.parse_args(["clear-cache", "--model", "owner/repo"])
-        assert args.model == "owner/repo"
-        assert hasattr(args, "cache_dir")
-
-    def test_clear_cache_with_cache_dir(self, parser):
-        args = parser.parse_args(["clear-cache", "--model", "owner/repo", "--cache-dir", "/tmp"])
-        assert args.cache_dir == "/tmp"
-
-    def test_clear_cache_dataset(self, parser):
-        args = parser.parse_args(["clear-cache", "--dataset", "owner/data"])
-        assert args.dataset == "owner/data"
-
-    def test_create_alias(self, parser):
-        args = parser.parse_args(["create", "owner/repo", "--repo-type", "model"])
-        assert args.repo_id == "owner/repo"
-        assert args.repo_type == "model"
-
-    def test_create_exist_ok(self, parser):
-        args = parser.parse_args([
-            "create", "owner/repo", "--repo-type", "model", "--exist-ok"
-        ])
-        assert args.exist_ok is True
-
-    def test_create_exist_ok_underscore(self, parser):
-        args = parser.parse_args([
-            "create", "owner/repo", "--repo-type", "model", "--exist_ok"
-        ])
-        assert args.exist_ok is True
-
-
-# ---------------------------------------------------------------------------
-# Upload backward compat
-# ---------------------------------------------------------------------------
-class TestUploadCompat:
-    def test_commit_description(self, parser):
-        args = parser.parse_args([
-            "upload", "owner/repo", ".", "--commit-description", "some desc"
-        ])
-        assert args.commit_description == "some desc"
-
-    def test_include_multi(self, parser):
-        args = parser.parse_args([
-            "upload", "owner/repo", ".", "--include", "*.py", "*.txt"
-        ])
-        assert args.allow_patterns == ["*.py", "*.txt"]
-
-    def test_subcmd_token(self, parser):
-        args = parser.parse_args([
-            "upload", "owner/repo", ".",
-            "--token", "ms-abc", "--endpoint", "https://x.cn",
-        ])
-        assert args.subcmd_token == "ms-abc"
-        assert args.subcmd_endpoint == "https://x.cn"
-
-
-# ---------------------------------------------------------------------------
-# Version flag
+# Version flag (short -V form, long --version is tested in test_main.py)
 # ---------------------------------------------------------------------------
 class TestVersionFlag:
-    def test_version_short(self, parser, capsys):
+    def test_version_short(self, parser):
         with pytest.raises(SystemExit) as exc_info:
             parser.parse_args(["-V"])
         assert exc_info.value.code == 0
 
-    def test_version_long(self, parser, capsys):
-        with pytest.raises(SystemExit) as exc_info:
-            parser.parse_args(["--version"])
-        assert exc_info.value.code == 0
-
 
 # ---------------------------------------------------------------------------
-# Repo create --exist-ok
+# Cross-cutting backward compat: --repo_type (underscore) in multiple commands
 # ---------------------------------------------------------------------------
-class TestRepoCreateExistOk:
-    def test_exist_ok_in_create(self, parser):
-        args = parser.parse_args([
-            "create", "owner/repo", "--repo-type", "model", "--exist-ok"
-        ])
-        assert args.exist_ok is True
-
-    def test_exist_ok_underscore(self, parser):
-        args = parser.parse_args([
-            "create", "owner/repo", "--repo-type", "model", "--exist_ok"
-        ])
-        assert args.exist_ok is True
-
-    def test_repo_create_compat(self, parser):
-        """``ms repo create`` still works as backward compat."""
-        args = parser.parse_args([
-            "repo", "create", "owner/repo", "--repo-type", "model", "--exist-ok"
-        ])
-        assert args.exist_ok is True
+class TestRepoTypeUnderscore:
+    @pytest.mark.parametrize("cmd,expected_type", [
+        (["info", "o/r", "--repo_type", "dataset"], "dataset"),
+        (["list", "--repo_type", "model"], "model"),
+        (["delete", "o/r", "--repo_type", "model"], "model"),
+    ])
+    def test_repo_type_underscore_in_all_commands(self, parser, cmd, expected_type):
+        """--repo_type (underscore) works in info, list, delete."""
+        args = parser.parse_args(cmd)
+        assert args.repo_type == expected_type

--- a/tests/cli/test_compat.py
+++ b/tests/cli/test_compat.py
@@ -266,14 +266,21 @@ class TestVersionFlag:
 # Repo create --exist-ok
 # ---------------------------------------------------------------------------
 class TestRepoCreateExistOk:
-    def test_exist_ok_in_repo_create(self, parser):
+    def test_exist_ok_in_create(self, parser):
         args = parser.parse_args([
-            "repo", "create", "owner/repo", "--repo-type", "model", "--exist-ok"
+            "create", "owner/repo", "--repo-type", "model", "--exist-ok"
         ])
         assert args.exist_ok is True
 
     def test_exist_ok_underscore(self, parser):
         args = parser.parse_args([
-            "repo", "create", "owner/repo", "--repo-type", "model", "--exist_ok"
+            "create", "owner/repo", "--repo-type", "model", "--exist_ok"
+        ])
+        assert args.exist_ok is True
+
+    def test_repo_create_compat(self, parser):
+        """``ms repo create`` still works as backward compat."""
+        args = parser.parse_args([
+            "repo", "create", "owner/repo", "--repo-type", "model", "--exist-ok"
         ])
         assert args.exist_ok is True

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -1,13 +1,266 @@
-"""Tests for ``ms deploy``, ``ms stop``, ``ms logs``, ``ms settings`` — real API."""
+"""Tests for ``ms deploy``, ``ms stop``, ``ms logs``, ``ms settings``.
+
+Includes:
+- Parser tests: all flags and repo-type choices
+- Execution tests: mock HubApi to verify command logic
+- Remote tests: real API lifecycle (existing)
+"""
 from __future__ import annotations
 
 import warnings
+from unittest.mock import patch
 
 import pytest
+
+from modelscope_hub.cli.deploy import (
+    DeployCommand,
+    LogsCommand,
+    SettingsCommand,
+    StopCommand,
+)
 
 from .conftest import run_cli
 
 
+# ===================================================================
+# Parser tests
+# ===================================================================
+class TestDeployParser:
+    """``ms deploy`` argument parsing."""
+
+    def test_basic(self, parser):
+        args = parser.parse_args(["deploy", "owner/studio"])
+        assert args.repo_id == "owner/studio"
+
+    def test_repo_type_default_studio(self, parser):
+        args = parser.parse_args(["deploy", "o/r"])
+        assert args.repo_type == "studio"
+
+    @pytest.mark.parametrize("repo_type", ["studio", "mcp"])
+    def test_repo_type_choices(self, parser, repo_type):
+        args = parser.parse_args(["deploy", "o/r", "--repo-type", repo_type])
+        assert args.repo_type == repo_type
+
+    def test_invalid_repo_type_rejected(self, parser):
+        with pytest.raises(SystemExit):
+            parser.parse_args(["deploy", "o/r", "--repo-type", "model"])
+
+
+class TestStopParser:
+    """``ms stop`` argument parsing."""
+
+    def test_basic(self, parser):
+        args = parser.parse_args(["stop", "owner/studio"])
+        assert args.repo_id == "owner/studio"
+
+    def test_repo_type_default_studio(self, parser):
+        args = parser.parse_args(["stop", "o/r"])
+        assert args.repo_type == "studio"
+
+    @pytest.mark.parametrize("repo_type", ["studio", "mcp"])
+    def test_repo_type_choices(self, parser, repo_type):
+        args = parser.parse_args(["stop", "o/r", "--repo-type", repo_type])
+        assert args.repo_type == repo_type
+
+    def test_invalid_repo_type_rejected(self, parser):
+        with pytest.raises(SystemExit):
+            parser.parse_args(["stop", "o/r", "--repo-type", "dataset"])
+
+
+class TestLogsParser:
+    """``ms logs`` argument parsing."""
+
+    def test_basic(self, parser):
+        args = parser.parse_args(["logs", "owner/studio"])
+        assert args.repo_id == "owner/studio"
+
+    def test_repo_type_default_studio(self, parser):
+        args = parser.parse_args(["logs", "o/r"])
+        assert args.repo_type == "studio"
+
+    def test_log_type_run(self, parser):
+        args = parser.parse_args(["logs", "o/r", "--log-type", "run"])
+        assert args.log_type == "run"
+
+    def test_log_type_build(self, parser):
+        args = parser.parse_args(["logs", "o/r", "--log-type", "build"])
+        assert args.log_type == "build"
+
+    def test_log_type_default_run(self, parser):
+        args = parser.parse_args(["logs", "o/r"])
+        assert args.log_type == "run"
+
+    def test_invalid_log_type_rejected(self, parser):
+        with pytest.raises(SystemExit):
+            parser.parse_args(["logs", "o/r", "--log-type", "deploy"])
+
+    def test_page_flags(self, parser):
+        args = parser.parse_args(["logs", "o/r", "--page", "3", "--page-size", "50"])
+        assert args.page_num == 3
+        assert args.page_size == 50
+
+    def test_page_defaults(self, parser):
+        args = parser.parse_args(["logs", "o/r"])
+        assert args.page_num == 1
+        assert args.page_size == 100
+
+    def test_keyword(self, parser):
+        args = parser.parse_args(["logs", "o/r", "--keyword", "ERROR"])
+        assert args.keyword == "ERROR"
+
+    def test_keyword_default_none(self, parser):
+        args = parser.parse_args(["logs", "o/r"])
+        assert args.keyword is None
+
+    def test_all_options_combined(self, parser):
+        args = parser.parse_args([
+            "logs", "org/demo",
+            "--log-type", "build",
+            "--page", "2",
+            "--page-size", "50",
+            "--keyword", "Exception",
+        ])
+        assert args.repo_id == "org/demo"
+        assert args.log_type == "build"
+        assert args.page_num == 2
+        assert args.page_size == 50
+        assert args.keyword == "Exception"
+
+
+class TestSettingsParser:
+    """``ms settings`` argument parsing."""
+
+    def test_basic(self, parser):
+        args = parser.parse_args(["settings", "owner/studio", "cpu=4"])
+        assert args.repo_id == "owner/studio"
+        assert args.settings == ["cpu=4"]
+
+    def test_multiple_kv(self, parser):
+        args = parser.parse_args(["settings", "o/r", "cpu=4", "memory=8192"])
+        assert args.settings == ["cpu=4", "memory=8192"]
+
+    def test_repo_type_default_studio(self, parser):
+        args = parser.parse_args(["settings", "o/r", "x=1"])
+        assert args.repo_type == "studio"
+
+    @pytest.mark.parametrize("repo_type", ["studio", "skill"])
+    def test_repo_type_choices(self, parser, repo_type):
+        args = parser.parse_args(["settings", "o/r", "x=1", "--repo-type", repo_type])
+        assert args.repo_type == repo_type
+
+    def test_invalid_repo_type_rejected(self, parser):
+        with pytest.raises(SystemExit):
+            parser.parse_args(["settings", "o/r", "x=1", "--repo-type", "model"])
+
+
+# ===================================================================
+# Execution tests — mock HubApi
+# ===================================================================
+class TestDeployExecute:
+    """DeployCommand.execute() logic."""
+
+    def test_deploy_studio(self, parser, mock_api, capsys):
+        args = parser.parse_args(["deploy", "org/demo", "--repo-type", "studio"])
+        with patch("modelscope_hub.cli.deploy.make_api", return_value=mock_api):
+            DeployCommand(args).execute()
+        mock_api.deploy_repo.assert_called_once_with("org/demo", "studio")
+        out = capsys.readouterr().out
+        assert "Deploy requested" in out
+
+    def test_deploy_mcp(self, parser, mock_api, capsys):
+        args = parser.parse_args(["deploy", "org/mcp-server", "--repo-type", "mcp"])
+        with patch("modelscope_hub.cli.deploy.make_api", return_value=mock_api):
+            DeployCommand(args).execute()
+        mock_api.deploy_repo.assert_called_once_with("org/mcp-server", "mcp")
+
+
+class TestStopExecute:
+    """StopCommand.execute() logic."""
+
+    def test_stop_studio(self, parser, mock_api, capsys):
+        args = parser.parse_args(["stop", "org/demo", "--repo-type", "studio"])
+        with patch("modelscope_hub.cli.deploy.make_api", return_value=mock_api):
+            StopCommand(args).execute()
+        mock_api.stop_repo.assert_called_once_with("org/demo", "studio")
+        out = capsys.readouterr().out
+        assert "Stop requested" in out
+
+    def test_stop_mcp(self, parser, mock_api, capsys):
+        args = parser.parse_args(["stop", "org/mcp-server", "--repo-type", "mcp"])
+        with patch("modelscope_hub.cli.deploy.make_api", return_value=mock_api):
+            StopCommand(args).execute()
+        mock_api.stop_repo.assert_called_once_with("org/mcp-server", "mcp")
+
+
+class TestLogsExecute:
+    """LogsCommand.execute() logic."""
+
+    def test_logs_with_list_payload(self, parser, mock_api, capsys):
+        args = parser.parse_args(["logs", "org/demo"])
+        with patch("modelscope_hub.cli.deploy.make_api", return_value=mock_api):
+            LogsCommand(args).execute()
+        mock_api.get_repo_logs.assert_called_once_with(
+            "org/demo", "studio",
+            log_type="run", page_num=1, page_size=100, keyword=None,
+        )
+        out = capsys.readouterr().out
+        assert "line1" in out
+        assert "line2" in out
+
+    def test_logs_with_keyword(self, parser, mock_api, capsys):
+        args = parser.parse_args(["logs", "org/demo", "--keyword", "ERROR"])
+        with patch("modelscope_hub.cli.deploy.make_api", return_value=mock_api):
+            LogsCommand(args).execute()
+        assert mock_api.get_repo_logs.call_args.kwargs["keyword"] == "ERROR"
+
+    def test_logs_build_type(self, parser, mock_api, capsys):
+        args = parser.parse_args(["logs", "org/demo", "--log-type", "build"])
+        with patch("modelscope_hub.cli.deploy.make_api", return_value=mock_api):
+            LogsCommand(args).execute()
+        assert mock_api.get_repo_logs.call_args.kwargs["log_type"] == "build"
+
+    def test_logs_empty_payload(self, parser, mock_api, capsys):
+        mock_api.get_repo_logs.return_value = {"logs": []}
+        args = parser.parse_args(["logs", "org/demo"])
+        with patch("modelscope_hub.cli.deploy.make_api", return_value=mock_api):
+            LogsCommand(args).execute()
+
+
+class TestSettingsExecute:
+    """SettingsCommand.execute() logic."""
+
+    def test_single_setting(self, parser, mock_api, capsys):
+        args = parser.parse_args(["settings", "org/demo", "cpu=4"])
+        with patch("modelscope_hub.cli.deploy.make_api", return_value=mock_api):
+            SettingsCommand(args).execute()
+        mock_api.update_repo_settings.assert_called_once_with(
+            "org/demo", "studio", cpu="4",
+        )
+        out = capsys.readouterr().out
+        assert "Updated 1 setting" in out
+
+    def test_multiple_settings(self, parser, mock_api, capsys):
+        args = parser.parse_args(["settings", "org/demo", "cpu=4", "memory=8192"])
+        with patch("modelscope_hub.cli.deploy.make_api", return_value=mock_api):
+            SettingsCommand(args).execute()
+        mock_api.update_repo_settings.assert_called_once_with(
+            "org/demo", "studio", cpu="4", memory="8192",
+        )
+        out = capsys.readouterr().out
+        assert "Updated 2 setting" in out
+
+    def test_settings_skill_type(self, parser, mock_api, capsys):
+        args = parser.parse_args([
+            "settings", "org/skill1", "timeout=30", "--repo-type", "skill",
+        ])
+        with patch("modelscope_hub.cli.deploy.make_api", return_value=mock_api):
+            SettingsCommand(args).execute()
+        assert mock_api.update_repo_settings.call_args.args[1] == "skill"
+
+
+# ===================================================================
+# Remote integration tests (existing)
+# ===================================================================
 @pytest.mark.remote
 class TestDeployLifecycle:
     """Test deploy/stop/logs/settings with real API on a studio repo."""

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -137,9 +137,10 @@ class TestLogsParser:
         assert args.page_size == 50
         assert args.keyword == "Exception"
 
-    def test_invalid_repo_type_rejected(self, parser):
+    @pytest.mark.parametrize("repo_type", ["model", "dataset", "mcp", "skill"])
+    def test_invalid_repo_type_rejected(self, parser, repo_type):
         with pytest.raises(SystemExit):
-            parser.parse_args(["logs", "o/r", "--repo-type", "model"])
+            parser.parse_args(["logs", "o/r", "--repo-type", repo_type])
 
     def test_page_num_alias(self, parser):
         args = parser.parse_args(["logs", "o/r", "--page-num", "5"])
@@ -171,9 +172,10 @@ class TestSettingsParser:
         args = parser.parse_args(["settings", "o/r", "x=1", "--repo-type", repo_type])
         assert args.repo_type == repo_type
 
-    def test_invalid_repo_type_rejected(self, parser):
+    @pytest.mark.parametrize("repo_type", ["model", "dataset", "mcp"])
+    def test_invalid_repo_type_rejected(self, parser, repo_type):
         with pytest.raises(SystemExit):
-            parser.parse_args(["settings", "o/r", "x=1", "--repo-type", "model"])
+            parser.parse_args(["settings", "o/r", "x=1", "--repo-type", repo_type])
 
     def test_missing_settings_args_exits(self, parser):
         with pytest.raises(SystemExit):

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -168,6 +168,7 @@ class TestSettingsParser:
 # ===================================================================
 # Execution tests — mock HubApi
 # ===================================================================
+@pytest.mark.mock_only
 class TestDeployExecute:
     """DeployCommand.execute() logic."""
 
@@ -186,6 +187,7 @@ class TestDeployExecute:
         mock_api.deploy_repo.assert_called_once_with("org/mcp-server", "mcp")
 
 
+@pytest.mark.mock_only
 class TestStopExecute:
     """StopCommand.execute() logic."""
 
@@ -204,6 +206,7 @@ class TestStopExecute:
         mock_api.stop_repo.assert_called_once_with("org/mcp-server", "mcp")
 
 
+@pytest.mark.mock_only
 class TestLogsExecute:
     """LogsCommand.execute() logic."""
 
@@ -246,6 +249,7 @@ class TestLogsExecute:
             LogsCommand(args).execute()
 
 
+@pytest.mark.mock_only
 class TestSettingsExecute:
     """SettingsCommand.execute() logic."""
 

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -126,6 +126,14 @@ class TestLogsParser:
         assert args.page_size == 50
         assert args.keyword == "Exception"
 
+    def test_invalid_repo_type_rejected(self, parser):
+        with pytest.raises(SystemExit):
+            parser.parse_args(["logs", "o/r", "--repo-type", "model"])
+
+    def test_page_num_alias(self, parser):
+        args = parser.parse_args(["logs", "o/r", "--page-num", "5"])
+        assert args.page_num == 5
+
 
 class TestSettingsParser:
     """``ms settings`` argument parsing."""
@@ -151,6 +159,10 @@ class TestSettingsParser:
     def test_invalid_repo_type_rejected(self, parser):
         with pytest.raises(SystemExit):
             parser.parse_args(["settings", "o/r", "x=1", "--repo-type", "model"])
+
+    def test_missing_settings_args_exits(self, parser):
+        with pytest.raises(SystemExit):
+            parser.parse_args(["settings", "o/r"])
 
 
 # ===================================================================
@@ -219,6 +231,14 @@ class TestLogsExecute:
             LogsCommand(args).execute()
         assert mock_api.get_repo_logs.call_args.kwargs["log_type"] == "build"
 
+    def test_logs_page_and_size_forwarded(self, parser, mock_api, capsys):
+        args = parser.parse_args(["logs", "org/demo", "--page", "3", "--page-size", "50"])
+        with patch("modelscope_hub.cli.deploy.make_api", return_value=mock_api):
+            LogsCommand(args).execute()
+        kw = mock_api.get_repo_logs.call_args.kwargs
+        assert kw["page_num"] == 3
+        assert kw["page_size"] == 50
+
     def test_logs_empty_payload(self, parser, mock_api, capsys):
         mock_api.get_repo_logs.return_value = {"logs": []}
         args = parser.parse_args(["logs", "org/demo"])
@@ -256,6 +276,12 @@ class TestSettingsExecute:
         with patch("modelscope_hub.cli.deploy.make_api", return_value=mock_api):
             SettingsCommand(args).execute()
         assert mock_api.update_repo_settings.call_args.args[1] == "skill"
+
+    def test_settings_invalid_kv_raises(self, parser, mock_api):
+        args = parser.parse_args(["settings", "org/demo", "bad"])
+        with patch("modelscope_hub.cli.deploy.make_api", return_value=mock_api):
+            with pytest.raises(ValueError, match="key=value"):
+                SettingsCommand(args).execute()
 
 
 # ===================================================================

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -36,6 +36,13 @@ class TestDeployParser:
         args = parser.parse_args(["deploy", "o/r"])
         assert args.repo_type == "studio"
 
+    def test_subcmd_token_endpoint(self, parser):
+        args = parser.parse_args([
+            "deploy", "o/r", "--token", "tk", "--endpoint", "https://x.cn",
+        ])
+        assert args.subcmd_token == "tk"
+        assert args.subcmd_endpoint == "https://x.cn"
+
     @pytest.mark.parametrize("repo_type", ["studio", "mcp"])
     def test_repo_type_choices(self, parser, repo_type):
         args = parser.parse_args(["deploy", "o/r", "--repo-type", repo_type])
@@ -56,6 +63,10 @@ class TestStopParser:
     def test_repo_type_default_studio(self, parser):
         args = parser.parse_args(["stop", "o/r"])
         assert args.repo_type == "studio"
+
+    def test_subcmd_token_endpoint(self, parser):
+        args = parser.parse_args(["stop", "o/r", "--token", "tk"])
+        assert args.subcmd_token == "tk"
 
     @pytest.mark.parametrize("repo_type", ["studio", "mcp"])
     def test_repo_type_choices(self, parser, repo_type):
@@ -134,6 +145,10 @@ class TestLogsParser:
         args = parser.parse_args(["logs", "o/r", "--page-num", "5"])
         assert args.page_num == 5
 
+    def test_subcmd_token_endpoint(self, parser):
+        args = parser.parse_args(["logs", "o/r", "--token", "tk"])
+        assert args.subcmd_token == "tk"
+
 
 class TestSettingsParser:
     """``ms settings`` argument parsing."""
@@ -163,6 +178,10 @@ class TestSettingsParser:
     def test_missing_settings_args_exits(self, parser):
         with pytest.raises(SystemExit):
             parser.parse_args(["settings", "o/r"])
+
+    def test_subcmd_token_endpoint(self, parser):
+        args = parser.parse_args(["settings", "o/r", "k=v", "--token", "tk"])
+        assert args.subcmd_token == "tk"
 
 
 # ===================================================================

--- a/tests/cli/test_download.py
+++ b/tests/cli/test_download.py
@@ -1,11 +1,250 @@
-"""Tests for ``ms download`` command — real API file download."""
+"""Tests for ``ms download`` command.
+
+Includes:
+- Parser tests: all flags, repo types, legacy args
+- Execution tests: mock HubApi for file/snapshot download logic
+- Remote tests: real API file download (existing)
+"""
 from __future__ import annotations
 
+import warnings
+from unittest.mock import patch
+
 import pytest
+
+from modelscope_hub.cli.download import DownloadCommand
 
 from .conftest import run_cli
 
 
+# ===================================================================
+# Parser tests
+# ===================================================================
+class TestDownloadParser:
+    """``ms download`` argument parsing."""
+
+    def test_positional_repo_id(self, parser):
+        args = parser.parse_args(["download", "owner/repo"])
+        assert args.repo_id == "owner/repo"
+
+    def test_positional_with_files(self, parser):
+        args = parser.parse_args(["download", "owner/repo", "a.bin", "b.json"])
+        assert args.repo_id == "owner/repo"
+        assert args.files == ["a.bin", "b.json"]
+
+    def test_repo_type_default_model(self, parser):
+        args = parser.parse_args(["download", "owner/repo"])
+        assert args.repo_type == "model"
+
+    @pytest.mark.parametrize("repo_type", ["model", "dataset", "studio"])
+    def test_repo_type_choices(self, parser, repo_type):
+        args = parser.parse_args(["download", "o/r", "--repo-type", repo_type])
+        assert args.repo_type == repo_type
+
+    def test_invalid_repo_type_rejected(self, parser):
+        with pytest.raises(SystemExit):
+            parser.parse_args(["download", "o/r", "--repo-type", "skill"])
+
+    def test_revision_flag(self, parser):
+        args = parser.parse_args(["download", "o/r", "--revision", "v2"])
+        assert args.revision == "v2"
+
+    def test_cache_dir(self, parser):
+        args = parser.parse_args(["download", "o/r", "--cache-dir", "/data/cache"])
+        assert args.cache_dir == "/data/cache"
+
+    def test_local_dir(self, parser):
+        args = parser.parse_args(["download", "o/r", "--local-dir", "./out"])
+        assert args.local_dir == "./out"
+
+    def test_max_workers(self, parser):
+        args = parser.parse_args(["download", "o/r", "--max-workers", "8"])
+        assert args.max_workers == 8
+
+    def test_max_workers_default(self, parser):
+        args = parser.parse_args(["download", "o/r"])
+        assert args.max_workers == 4
+
+    def test_force_flag(self, parser):
+        args = parser.parse_args(["download", "o/r", "--force"])
+        assert args.force is True
+
+    def test_force_default_false(self, parser):
+        args = parser.parse_args(["download", "o/r"])
+        assert args.force is False
+
+    def test_include_single(self, parser):
+        args = parser.parse_args(["download", "o/r", "--include", "*.safetensors"])
+        assert args.allow_patterns == ["*.safetensors"]
+
+    def test_include_multi(self, parser):
+        args = parser.parse_args(["download", "o/r", "--include", "*.bin", "*.json"])
+        assert args.allow_patterns == ["*.bin", "*.json"]
+
+    def test_include_repeated(self, parser):
+        args = parser.parse_args([
+            "download", "o/r", "--include", "*.bin", "--include", "*.json",
+        ])
+        assert "*.bin" in args.allow_patterns
+        assert "*.json" in args.allow_patterns
+
+    def test_exclude_single(self, parser):
+        args = parser.parse_args(["download", "o/r", "--exclude", "*.gguf"])
+        assert args.ignore_patterns == ["*.gguf"]
+
+    def test_exclude_multi(self, parser):
+        args = parser.parse_args(["download", "o/r", "--exclude", "*.bin", "*.gguf"])
+        assert args.ignore_patterns == ["*.bin", "*.gguf"]
+
+    def test_include_and_exclude(self, parser):
+        args = parser.parse_args([
+            "download", "o/r",
+            "--include", "*.safetensors",
+            "--exclude", "*.bin", "*.gguf",
+        ])
+        assert args.allow_patterns == ["*.safetensors"]
+        assert args.ignore_patterns == ["*.bin", "*.gguf"]
+
+    def test_all_options_combined(self, parser):
+        args = parser.parse_args([
+            "download", "Qwen/Qwen3-0.6B",
+            "--repo-type", "model",
+            "--revision", "main",
+            "--cache-dir", "/cache",
+            "--local-dir", "./out",
+            "--max-workers", "16",
+            "--include", "*.safetensors",
+            "--exclude", "*.bin",
+            "--force",
+        ])
+        assert args.repo_id == "Qwen/Qwen3-0.6B"
+        assert args.repo_type == "model"
+        assert args.revision == "main"
+        assert args.cache_dir == "/cache"
+        assert args.local_dir == "./out"
+        assert args.max_workers == 16
+        assert args.force is True
+
+    def test_repo_type_underscore(self, parser):
+        args = parser.parse_args(["download", "o/r", "--repo_type", "dataset"])
+        assert args.repo_type == "dataset"
+
+
+class TestDownloadLegacyParser:
+    """Legacy ``--model``/``--dataset``/``--collection`` flags."""
+
+    def test_model_flag(self, parser):
+        args = parser.parse_args(["download", "--model", "owner/repo"])
+        assert args.model == "owner/repo"
+
+    def test_dataset_flag(self, parser):
+        args = parser.parse_args(["download", "--dataset", "owner/data"])
+        assert args.dataset == "owner/data"
+
+    def test_collection_flag(self, parser):
+        args = parser.parse_args(["download", "--collection", "my-collection"])
+        assert args.collection == "my-collection"
+
+    def test_model_dataset_mutually_exclusive(self, parser):
+        with pytest.raises(SystemExit):
+            parser.parse_args(["download", "--model", "a", "--dataset", "b"])
+
+    def test_legacy_local_dir_underscore(self, parser):
+        args = parser.parse_args(["download", "--model", "o/r", "--local_dir", "/tmp"])
+        assert args.local_dir_legacy == "/tmp"
+
+    def test_legacy_cache_dir_underscore(self, parser):
+        args = parser.parse_args(["download", "--model", "o/r", "--cache_dir", "/cache"])
+        assert args.cache_dir_legacy == "/cache"
+
+    def test_subcmd_token_endpoint(self, parser):
+        args = parser.parse_args([
+            "download", "--model", "o/r",
+            "--token", "ms-xxx", "--endpoint", "https://custom.cn",
+        ])
+        assert args.subcmd_token == "ms-xxx"
+        assert args.subcmd_endpoint == "https://custom.cn"
+
+
+# ===================================================================
+# Execution tests — mock HubApi
+# ===================================================================
+class TestDownloadExecute:
+    """DownloadCommand.execute() logic with mocked API."""
+
+    def _patch_download_api(self, mock_api):
+        """Patch both ``make_api`` and ``HubApi`` so ``_make_api_with_endpoint``
+        resolves through its natural code path without hitting the network."""
+        return (
+            patch("modelscope_hub.cli.download.make_api", return_value=mock_api),
+            patch("modelscope_hub.cli.download.HubApi", return_value=mock_api),
+        )
+
+    def test_single_file(self, parser, mock_api, capsys):
+        args = parser.parse_args([
+            "download", "owner/repo", "config.json", "--cache-dir", "/tmp/cache",
+        ])
+        p1, p2 = self._patch_download_api(mock_api)
+        with p1, p2:
+            DownloadCommand(args).execute()
+        mock_api.download_file.assert_called_once()
+        call_args = mock_api.download_file.call_args
+        assert call_args.args[0] == "owner/repo"
+        assert call_args.args[2] == "config.json"
+        out = capsys.readouterr().out
+        assert "config.json" in out
+
+    def test_multiple_files(self, parser, mock_api, capsys):
+        args = parser.parse_args([
+            "download", "owner/repo", "a.bin", "b.json",
+        ])
+        p1, p2 = self._patch_download_api(mock_api)
+        with p1, p2:
+            DownloadCommand(args).execute()
+        assert mock_api.download_file.call_count == 2
+
+    def test_snapshot(self, parser, mock_api, capsys):
+        args = parser.parse_args(["download", "owner/repo"])
+        p1, p2 = self._patch_download_api(mock_api)
+        with p1, p2:
+            DownloadCommand(args).execute()
+        mock_api.download_repo.assert_called_once()
+        out = capsys.readouterr().out
+        assert "Snapshot ready" in out
+
+    def test_snapshot_with_patterns(self, parser, mock_api, capsys):
+        args = parser.parse_args([
+            "download", "owner/repo",
+            "--include", "*.safetensors",
+            "--exclude", "*.bin",
+        ])
+        p1, p2 = self._patch_download_api(mock_api)
+        with p1, p2:
+            DownloadCommand(args).execute()
+        call_kwargs = mock_api.download_repo.call_args.kwargs
+        assert call_kwargs["allow_patterns"] == ["*.safetensors"]
+        assert call_kwargs["ignore_patterns"] == ["*.bin"]
+
+    def test_force_forwarded(self, parser, mock_api, capsys):
+        args = parser.parse_args(["download", "owner/repo", "f.txt", "--force"])
+        p1, p2 = self._patch_download_api(mock_api)
+        with p1, p2:
+            DownloadCommand(args).execute()
+        assert mock_api.download_file.call_args.kwargs["force"] is True
+
+    def test_dataset_repo_type(self, parser, mock_api, capsys):
+        args = parser.parse_args([
+            "download", "org/data", "--repo-type", "dataset",
+        ])
+        p1, p2 = self._patch_download_api(mock_api)
+        with p1, p2:
+            DownloadCommand(args).execute()
+        assert mock_api.download_repo.call_args.args[1] == "dataset"
+
+
+# ===================================================================
+# Remote integration tests (existing)
+# ===================================================================
 @pytest.mark.remote
 class TestDownloadLifecycle:
     """Test file download with real API.
@@ -52,7 +291,6 @@ class TestDownloadLifecycle:
         cls.api = api
         print("** Setup: done")
         yield
-        import warnings
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             try:

--- a/tests/cli/test_download.py
+++ b/tests/cli/test_download.py
@@ -14,6 +14,8 @@ import pytest
 
 from modelscope_hub.cli.download import DownloadCommand
 
+from pathlib import Path
+
 from .conftest import run_cli
 
 
@@ -240,6 +242,55 @@ class TestDownloadExecute:
         with p1, p2:
             DownloadCommand(args).execute()
         assert mock_api.download_repo.call_args.args[1] == "dataset"
+
+    def test_local_dir_forwarded(self, parser, mock_api, capsys):
+        args = parser.parse_args(["download", "o/r", "--local-dir", "./out"])
+        p1, p2 = self._patch_download_api(mock_api)
+        with p1, p2:
+            DownloadCommand(args).execute()
+        assert mock_api.download_repo.call_args.kwargs["local_dir"] == Path("./out")
+
+    def test_cache_dir_forwarded(self, parser, mock_api, capsys):
+        args = parser.parse_args(["download", "o/r", "--cache-dir", "/cache"])
+        p1, p2 = self._patch_download_api(mock_api)
+        with p1, p2:
+            DownloadCommand(args).execute()
+        assert mock_api.download_repo.call_args.kwargs["cache_dir"] == Path("/cache")
+
+    def test_revision_forwarded(self, parser, mock_api, capsys):
+        args = parser.parse_args(["download", "o/r", "--revision", "v2"])
+        p1, p2 = self._patch_download_api(mock_api)
+        with p1, p2:
+            DownloadCommand(args).execute()
+        assert mock_api.download_repo.call_args.kwargs["revision"] == "v2"
+
+    def test_max_workers_forwarded(self, parser, mock_api, capsys):
+        args = parser.parse_args(["download", "o/r", "--max-workers", "16"])
+        p1, p2 = self._patch_download_api(mock_api)
+        with p1, p2:
+            DownloadCommand(args).execute()
+        assert mock_api.download_repo.call_args.kwargs["max_workers"] == 16
+
+    def test_studio_repo_type(self, parser, mock_api, capsys):
+        args = parser.parse_args(["download", "o/r", "--repo-type", "studio"])
+        p1, p2 = self._patch_download_api(mock_api)
+        with p1, p2:
+            DownloadCommand(args).execute()
+        assert mock_api.download_repo.call_args.args[1] == "studio"
+
+    def test_collection_download(self, parser, mock_api, capsys):
+        args = parser.parse_args(["download", "--collection", "my-col"])
+        mock_api.legacy.get_collection.return_value = {
+            "CollectionElements": {
+                "CollectionElementVoList": [
+                    {"ElementPath": "org", "ElementName": "skill1"},
+                ],
+            },
+        }
+        with patch("modelscope_hub.cli.download.make_api", return_value=mock_api):
+            DownloadCommand(args).execute()
+        mock_api.legacy.get_collection.assert_called_once_with("my-col")
+        assert mock_api.download_repo.call_count == 1
 
 
 # ===================================================================

--- a/tests/cli/test_download.py
+++ b/tests/cli/test_download.py
@@ -38,14 +38,15 @@ class TestDownloadParser:
         args = parser.parse_args(["download", "owner/repo"])
         assert args.repo_type == "model"
 
-    @pytest.mark.parametrize("repo_type", ["model", "dataset", "studio"])
+    @pytest.mark.parametrize("repo_type", ["model", "dataset"])
     def test_repo_type_choices(self, parser, repo_type):
         args = parser.parse_args(["download", "o/r", "--repo-type", repo_type])
         assert args.repo_type == repo_type
 
-    def test_invalid_repo_type_rejected(self, parser):
+    @pytest.mark.parametrize("repo_type", ["studio", "skill"])
+    def test_invalid_repo_type_rejected(self, parser, repo_type):
         with pytest.raises(SystemExit):
-            parser.parse_args(["download", "o/r", "--repo-type", "skill"])
+            parser.parse_args(["download", "o/r", "--repo-type", repo_type])
 
     def test_revision_flag(self, parser):
         args = parser.parse_args(["download", "o/r", "--revision", "v2"])
@@ -272,12 +273,9 @@ class TestDownloadExecute:
             DownloadCommand(args).execute()
         assert mock_api.download_repo.call_args.kwargs["max_workers"] == 16
 
-    def test_studio_repo_type(self, parser, mock_api, capsys):
-        args = parser.parse_args(["download", "o/r", "--repo-type", "studio"])
-        p1, p2 = self._patch_download_api(mock_api)
-        with p1, p2:
-            DownloadCommand(args).execute()
-        assert mock_api.download_repo.call_args.args[1] == "studio"
+    def test_studio_repo_type_rejected(self, parser, mock_api, capsys):
+        with pytest.raises(SystemExit):
+            parser.parse_args(["download", "o/r", "--repo-type", "studio"])
 
     def test_collection_download(self, parser, mock_api, capsys):
         args = parser.parse_args(["download", "--collection", "my-col"])

--- a/tests/cli/test_download.py
+++ b/tests/cli/test_download.py
@@ -171,6 +171,7 @@ class TestDownloadLegacyParser:
 # ===================================================================
 # Execution tests — mock HubApi
 # ===================================================================
+@pytest.mark.mock_only
 class TestDownloadExecute:
     """DownloadCommand.execute() logic with mocked API."""
 

--- a/tests/cli/test_login.py
+++ b/tests/cli/test_login.py
@@ -47,6 +47,7 @@ class TestWhoamiParser:
 # ===================================================================
 # Execution tests — mock HubApi
 # ===================================================================
+@pytest.mark.mock_only
 class TestLoginExecute:
     """LoginCommand.execute() logic."""
 
@@ -123,6 +124,7 @@ class TestLoginExecute:
         assert args.endpoint == "https://custom.cn"
 
 
+@pytest.mark.mock_only
 class TestWhoamiExecute:
     """WhoamiCommand.execute() logic."""
 

--- a/tests/cli/test_login.py
+++ b/tests/cli/test_login.py
@@ -43,6 +43,13 @@ class TestWhoamiParser:
         args = parser.parse_args(["whoami"])
         assert hasattr(args, "_command")
 
+    def test_subcmd_token_endpoint(self, parser):
+        args = parser.parse_args([
+            "whoami", "--token", "my-tok", "--endpoint", "https://x.cn",
+        ])
+        assert args.subcmd_token == "my-tok"
+        assert args.subcmd_endpoint == "https://x.cn"
+
 
 # ===================================================================
 # Execution tests — mock HubApi

--- a/tests/cli/test_login.py
+++ b/tests/cli/test_login.py
@@ -1,11 +1,153 @@
-"""Tests for ``ms login`` and ``ms whoami`` commands — real API."""
+"""Tests for ``ms login`` and ``ms whoami`` commands.
+
+Includes:
+- Parser tests: argument parsing
+- Execution tests: mock HubApi for login/whoami logic
+- Remote tests: real API (existing)
+"""
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
+
+from modelscope_hub.cli.login import LoginCommand, WhoamiCommand
+from modelscope_hub.types import UserInfo
 
 from .conftest import run_cli
 
 
+# ===================================================================
+# Parser tests
+# ===================================================================
+class TestLoginParser:
+    """``ms login`` argument parsing."""
+
+    def test_no_args(self, parser):
+        args = parser.parse_args(["login"])
+        assert args.login_token is None
+
+    def test_with_token(self, parser):
+        args = parser.parse_args(["login", "--token", "my-token-123"])
+        assert args.login_token == "my-token-123"
+
+    def test_subcmd_endpoint(self, parser):
+        args = parser.parse_args(["login", "--endpoint", "https://custom.cn"])
+        assert args.subcmd_endpoint == "https://custom.cn"
+
+
+class TestWhoamiParser:
+    """``ms whoami`` argument parsing."""
+
+    def test_no_args(self, parser):
+        args = parser.parse_args(["whoami"])
+        assert hasattr(args, "_command")
+
+
+# ===================================================================
+# Execution tests — mock HubApi
+# ===================================================================
+class TestLoginExecute:
+    """LoginCommand.execute() logic."""
+
+    def test_login_with_token_flag(self, parser, mock_api, capsys):
+        args = parser.parse_args(["login", "--token", "my-token"])
+        with patch("modelscope_hub.cli.login.make_api", return_value=mock_api):
+            LoginCommand(args).execute()
+        mock_api.login.assert_called_once_with("my-token")
+        out = capsys.readouterr().out
+        assert "Logged in as" in out
+        assert "testuser" in out
+
+    def test_login_with_global_token(self, parser, mock_api, capsys):
+        args = parser.parse_args(["--token", "global-tok", "login"])
+        with patch("modelscope_hub.cli.login.make_api", return_value=mock_api):
+            LoginCommand(args).execute()
+        mock_api.login.assert_called_once_with("global-tok")
+
+    def test_login_interactive(self, parser, mock_api, capsys):
+        args = parser.parse_args(["login"])
+        with (
+            patch("modelscope_hub.cli.login.make_api", return_value=mock_api),
+            patch("modelscope_hub.cli.login.getpass.getpass", return_value="interactive-tok"),
+        ):
+            LoginCommand(args).execute()
+        mock_api.login.assert_called_once_with("interactive-tok")
+
+    def test_login_empty_token_exits(self, parser, mock_api):
+        args = parser.parse_args(["login"])
+        with (
+            patch("modelscope_hub.cli.login.make_api", return_value=mock_api),
+            patch("modelscope_hub.cli.login.getpass.getpass", return_value=""),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                LoginCommand(args).execute()
+            assert exc_info.value.code == 2
+
+    def test_login_whitespace_only_exits(self, parser, mock_api):
+        args = parser.parse_args(["login"])
+        with (
+            patch("modelscope_hub.cli.login.make_api", return_value=mock_api),
+            patch("modelscope_hub.cli.login.getpass.getpass", return_value="   "),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                LoginCommand(args).execute()
+            assert exc_info.value.code == 2
+
+    def test_login_ctrl_c_exits_130(self, parser, mock_api):
+        args = parser.parse_args(["login"])
+        with (
+            patch("modelscope_hub.cli.login.make_api", return_value=mock_api),
+            patch("modelscope_hub.cli.login.getpass.getpass", side_effect=KeyboardInterrupt),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                LoginCommand(args).execute()
+            assert exc_info.value.code == 130
+
+    def test_login_eof_exits_130(self, parser, mock_api):
+        args = parser.parse_args(["login"])
+        with (
+            patch("modelscope_hub.cli.login.make_api", return_value=mock_api),
+            patch("modelscope_hub.cli.login.getpass.getpass", side_effect=EOFError),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                LoginCommand(args).execute()
+            assert exc_info.value.code == 130
+
+    def test_login_subcmd_endpoint_merged(self, parser, mock_api, capsys):
+        args = parser.parse_args([
+            "login", "--token", "tok", "--endpoint", "https://custom.cn",
+        ])
+        with patch("modelscope_hub.cli.login.make_api", return_value=mock_api):
+            LoginCommand(args).execute()
+        assert args.endpoint == "https://custom.cn"
+
+
+class TestWhoamiExecute:
+    """WhoamiCommand.execute() logic."""
+
+    def test_whoami_prints_user_info(self, parser, mock_api, capsys):
+        args = parser.parse_args(["whoami"])
+        with patch("modelscope_hub.cli.login.make_api", return_value=mock_api):
+            WhoamiCommand(args).execute()
+        mock_api.whoami.assert_called_once()
+        out = capsys.readouterr().out
+        assert "testuser" in out
+        assert "test@example.com" in out
+        assert "42" in out
+
+    def test_whoami_missing_fields(self, parser, mock_api, capsys):
+        mock_api.whoami.return_value = UserInfo()
+        args = parser.parse_args(["whoami"])
+        with patch("modelscope_hub.cli.login.make_api", return_value=mock_api):
+            WhoamiCommand(args).execute()
+        out = capsys.readouterr().out
+        assert "-" in out
+
+
+# ===================================================================
+# Remote integration tests (existing)
+# ===================================================================
 @pytest.mark.remote
 class TestLogin:
     """Test login with real API credentials."""

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -81,6 +81,7 @@ class TestGlobalParameterParsing:
 # ---------------------------------------------------------------------------
 # Exception handling (unit tests with mocks — no API needed)
 # ---------------------------------------------------------------------------
+@pytest.mark.mock_only
 class TestExceptionHandlingUnit:
     """Verify run_cmd translates exceptions into correct exit codes."""
 

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -115,7 +115,7 @@ class TestExceptionHandling:
     def test_invalid_repo_id_exits_2(self, test_token, test_endpoint):
         """Malformed repo_id → ValueError → exit 2."""
         exit_code, out, err = run_cli(
-            ["repo", "info", "no-slash-invalid", "--repo-type", "model"],
+            ["info", "no-slash-invalid", "--repo-type", "model"],
             token=test_token,
             endpoint=test_endpoint,
         )
@@ -126,7 +126,7 @@ class TestExceptionHandling:
     def test_nonexistent_repo_exits_1(self, test_token, test_endpoint):
         """Non-existent repo → HubError (404) → exit 1."""
         exit_code, out, err = run_cli(
-            ["repo", "info", "nonexistent_owner_xyz/nonexistent_repo_xyz", "--repo-type", "model"],
+            ["info", "nonexistent_owner_xyz/nonexistent_repo_xyz", "--repo-type", "model"],
             token=test_token,
             endpoint=test_endpoint,
         )

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -2,11 +2,13 @@
 from __future__ import annotations
 
 import logging
+from unittest.mock import patch
 
 import pytest
 
 from modelscope_hub import __version__
 from modelscope_hub.cli.main import run_cmd
+from modelscope_hub.errors import HubError, InvalidParameter, NetworkError, NotSupportedError
 
 from .conftest import run_cli
 
@@ -39,6 +41,107 @@ class TestVersionAndHelp:
             run_cmd([])
         print(f"\n** [no subcommand] exit_code={exc_info.value.code}")
         assert exc_info.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# Global parameter parsing
+# ---------------------------------------------------------------------------
+class TestGlobalParameterParsing:
+    """Verify global --token, --endpoint, --verbose are parsed correctly."""
+
+    def test_global_token(self, parser):
+        args = parser.parse_args(["--token", "my-tok", "whoami"])
+        assert args.token == "my-tok"
+
+    def test_global_endpoint(self, parser):
+        args = parser.parse_args(["--endpoint", "https://custom.cn", "whoami"])
+        assert args.endpoint == "https://custom.cn"
+
+    def test_global_verbose(self, parser):
+        args = parser.parse_args(["--verbose", "whoami"])
+        assert args.verbose is True
+
+    def test_verbose_short(self, parser):
+        args = parser.parse_args(["-v", "whoami"])
+        assert args.verbose is True
+
+    def test_verbose_default_false(self, parser):
+        args = parser.parse_args(["whoami"])
+        assert args.verbose is False
+
+    def test_global_flags_before_subcommand(self, parser):
+        args = parser.parse_args([
+            "--token", "tok", "--endpoint", "https://x.cn", "-v", "whoami",
+        ])
+        assert args.token == "tok"
+        assert args.endpoint == "https://x.cn"
+        assert args.verbose is True
+
+
+# ---------------------------------------------------------------------------
+# Exception handling (unit tests with mocks — no API needed)
+# ---------------------------------------------------------------------------
+class TestExceptionHandlingUnit:
+    """Verify run_cmd translates exceptions into correct exit codes."""
+
+    def test_hub_error_exits_1(self):
+        with patch("modelscope_hub.cli.login.make_api") as mock_make:
+            mock_make.return_value.whoami.side_effect = HubError("server error")
+            code, out, err = run_cli(["whoami"], token="fake")
+        assert code == 1
+        assert "server error" in err
+
+    def test_invalid_parameter_exits_2(self):
+        exc = InvalidParameter("bad param")
+        exc.suggestion = "try X"
+        with patch("modelscope_hub.cli.login.make_api") as mock_make:
+            mock_make.return_value.whoami.side_effect = exc
+            code, out, err = run_cli(["whoami"], token="fake")
+        assert code == 2
+        assert "bad param" in err
+        assert "try X" in out
+
+    def test_not_supported_error_exits_2(self):
+        with patch("modelscope_hub.cli.login.make_api") as mock_make:
+            mock_make.return_value.whoami.side_effect = NotSupportedError(
+                "not supported", suggestion="use Y"
+            )
+            code, out, err = run_cli(["whoami"], token="fake")
+        assert code == 2
+        assert "not supported" in err
+
+    def test_network_error_exits_1(self):
+        with patch("modelscope_hub.cli.login.make_api") as mock_make:
+            mock_make.return_value.whoami.side_effect = NetworkError("connection refused")
+            code, out, err = run_cli(["whoami"], token="fake")
+        assert code == 1
+        assert "connection refused" in err
+
+    def test_value_error_exits_2(self):
+        with patch("modelscope_hub.cli.login.make_api") as mock_make:
+            mock_make.return_value.whoami.side_effect = ValueError("invalid input")
+            code, out, err = run_cli(["whoami"], token="fake")
+        assert code == 2
+        assert "invalid input" in err
+
+    def test_not_implemented_error_exits_2(self):
+        with patch("modelscope_hub.cli.login.make_api") as mock_make:
+            mock_make.return_value.whoami.side_effect = NotImplementedError("not yet")
+            code, out, err = run_cli(["whoami"], token="fake")
+        assert code == 2
+        assert "not yet" in err
+
+    def test_keyboard_interrupt_exits_130(self):
+        with patch("modelscope_hub.cli.login.make_api") as mock_make:
+            mock_make.return_value.whoami.side_effect = KeyboardInterrupt
+            code, out, err = run_cli(["whoami"], token="fake")
+        assert code == 130
+
+    def test_system_exit_forwarded(self):
+        with patch("modelscope_hub.cli.login.make_api") as mock_make:
+            mock_make.return_value.whoami.side_effect = SystemExit(42)
+            code, out, err = run_cli(["whoami"], token="fake")
+        assert code == 42
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_mcp.py
+++ b/tests/cli/test_mcp.py
@@ -99,6 +99,7 @@ class TestMcpUndeployParser:
 # ===================================================================
 # Execution tests — mock HubApi
 # ===================================================================
+@pytest.mark.mock_only
 class TestMcpListExecute:
     def test_list_with_results(self, parser, mock_api, capsys):
         args = parser.parse_args(["mcp", "list"])
@@ -135,6 +136,7 @@ class TestMcpListExecute:
         assert kw["page_size"] == 5
 
 
+@pytest.mark.mock_only
 class TestMcpInfoExecute:
     def test_info_prints_json(self, parser, mock_api, capsys):
         args = parser.parse_args(["mcp", "info", "org/weather-mcp"])
@@ -145,6 +147,7 @@ class TestMcpInfoExecute:
         assert "weather" in out
 
 
+@pytest.mark.mock_only
 class TestMcpDeployExecute:
     def test_deploy(self, parser, mock_api, capsys):
         args = parser.parse_args(["mcp", "deploy", "org/weather-mcp"])
@@ -155,6 +158,7 @@ class TestMcpDeployExecute:
         assert "Deploy requested" in out
 
 
+@pytest.mark.mock_only
 class TestMcpUndeployExecute:
     def test_undeploy(self, parser, mock_api, capsys):
         args = parser.parse_args(["mcp", "undeploy", "org/weather-mcp"])

--- a/tests/cli/test_mcp.py
+++ b/tests/cli/test_mcp.py
@@ -1,11 +1,173 @@
-"""Tests for ``ms mcp`` group — real API MCP server operations."""
+"""Tests for ``ms mcp`` group — list / info / deploy / undeploy.
+
+Includes:
+- Parser tests: all subcommands and flags
+- Execution tests: mock HubApi for MCP server operations
+- Remote tests: real API (existing)
+"""
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
+
+from modelscope_hub.cli.mcp import _McpDeploy, _McpInfo, _McpList, _McpUndeploy
+from modelscope_hub.types import PagedResult
 
 from .conftest import run_cli
 
 
+# ===================================================================
+# Parser tests
+# ===================================================================
+class TestMcpListParser:
+    """``ms mcp list`` argument parsing."""
+
+    def test_basic(self, parser):
+        args = parser.parse_args(["mcp", "list"])
+        assert hasattr(args, "_mcp_leaf")
+
+    def test_search(self, parser):
+        args = parser.parse_args(["mcp", "list", "--search", "weather"])
+        assert args.search == "weather"
+
+    def test_search_default_none(self, parser):
+        args = parser.parse_args(["mcp", "list"])
+        assert args.search is None
+
+    def test_page(self, parser):
+        args = parser.parse_args(["mcp", "list", "--page", "3"])
+        assert args.page_number == 3
+
+    def test_page_size(self, parser):
+        args = parser.parse_args(["mcp", "list", "--page-size", "10"])
+        assert args.page_size == 10
+
+    def test_page_defaults(self, parser):
+        args = parser.parse_args(["mcp", "list"])
+        assert args.page_number == 1
+        assert args.page_size == 20
+
+    def test_all_options(self, parser):
+        args = parser.parse_args([
+            "mcp", "list",
+            "--search", "test",
+            "--page", "2",
+            "--page-size", "50",
+        ])
+        assert args.search == "test"
+        assert args.page_number == 2
+        assert args.page_size == 50
+
+
+class TestMcpInfoParser:
+    """``ms mcp info`` argument parsing."""
+
+    def test_basic(self, parser):
+        args = parser.parse_args(["mcp", "info", "org/weather-mcp"])
+        assert args.server_id == "org/weather-mcp"
+
+    def test_missing_server_id_exits(self, parser):
+        with pytest.raises(SystemExit):
+            parser.parse_args(["mcp", "info"])
+
+
+class TestMcpDeployParser:
+    """``ms mcp deploy`` argument parsing."""
+
+    def test_basic(self, parser):
+        args = parser.parse_args(["mcp", "deploy", "org/weather-mcp"])
+        assert args.server_id == "org/weather-mcp"
+
+    def test_missing_server_id_exits(self, parser):
+        with pytest.raises(SystemExit):
+            parser.parse_args(["mcp", "deploy"])
+
+
+class TestMcpUndeployParser:
+    """``ms mcp undeploy`` argument parsing."""
+
+    def test_basic(self, parser):
+        args = parser.parse_args(["mcp", "undeploy", "org/weather-mcp"])
+        assert args.server_id == "org/weather-mcp"
+
+    def test_missing_server_id_exits(self, parser):
+        with pytest.raises(SystemExit):
+            parser.parse_args(["mcp", "undeploy"])
+
+
+# ===================================================================
+# Execution tests — mock HubApi
+# ===================================================================
+class TestMcpListExecute:
+    def test_list_with_results(self, parser, mock_api, capsys):
+        args = parser.parse_args(["mcp", "list"])
+        with patch("modelscope_hub.cli.mcp.make_api", return_value=mock_api):
+            _McpList(args).execute()
+        mock_api.list_mcp_servers.assert_called_once_with(
+            search=None, page_number=1, page_size=20,
+        )
+        out = capsys.readouterr().out
+        assert "weather" in out
+
+    def test_list_empty(self, parser, mock_api, capsys):
+        mock_api.list_mcp_servers.return_value = PagedResult(
+            items=[], total_count=0, page_number=1, page_size=20,
+        )
+        args = parser.parse_args(["mcp", "list"])
+        with patch("modelscope_hub.cli.mcp.make_api", return_value=mock_api):
+            _McpList(args).execute()
+        out = capsys.readouterr().out
+        assert "no MCP servers found" in out
+
+    def test_list_with_search(self, parser, mock_api, capsys):
+        args = parser.parse_args(["mcp", "list", "--search", "weather"])
+        with patch("modelscope_hub.cli.mcp.make_api", return_value=mock_api):
+            _McpList(args).execute()
+        assert mock_api.list_mcp_servers.call_args.kwargs["search"] == "weather"
+
+    def test_list_with_pagination(self, parser, mock_api, capsys):
+        args = parser.parse_args(["mcp", "list", "--page", "2", "--page-size", "5"])
+        with patch("modelscope_hub.cli.mcp.make_api", return_value=mock_api):
+            _McpList(args).execute()
+        kw = mock_api.list_mcp_servers.call_args.kwargs
+        assert kw["page_number"] == 2
+        assert kw["page_size"] == 5
+
+
+class TestMcpInfoExecute:
+    def test_info_prints_json(self, parser, mock_api, capsys):
+        args = parser.parse_args(["mcp", "info", "org/weather-mcp"])
+        with patch("modelscope_hub.cli.mcp.make_api", return_value=mock_api):
+            _McpInfo(args).execute()
+        mock_api.get_mcp_server.assert_called_once_with("org/weather-mcp")
+        out = capsys.readouterr().out
+        assert "weather" in out
+
+
+class TestMcpDeployExecute:
+    def test_deploy(self, parser, mock_api, capsys):
+        args = parser.parse_args(["mcp", "deploy", "org/weather-mcp"])
+        with patch("modelscope_hub.cli.mcp.make_api", return_value=mock_api):
+            _McpDeploy(args).execute()
+        mock_api.deploy_mcp_server.assert_called_once_with("org/weather-mcp")
+        out = capsys.readouterr().out
+        assert "Deploy requested" in out
+
+
+class TestMcpUndeployExecute:
+    def test_undeploy(self, parser, mock_api, capsys):
+        args = parser.parse_args(["mcp", "undeploy", "org/weather-mcp"])
+        with patch("modelscope_hub.cli.mcp.make_api", return_value=mock_api):
+            _McpUndeploy(args).execute()
+        mock_api.undeploy_mcp_server.assert_called_once_with("org/weather-mcp")
+        out = capsys.readouterr().out
+        assert "Undeploy requested" in out
+
+
+# ===================================================================
+# Remote integration tests (existing)
+# ===================================================================
 @pytest.mark.remote
 class TestMcpOperations:
     """Test MCP server operations with real API."""
@@ -20,7 +182,6 @@ class TestMcpOperations:
         print(f"\n** [mcp list]")
         print(f"** exit_code={exit_code}, out={out[:300]!r}, err={err!r}")
         assert exit_code == 0
-        # May have servers or show "no MCP servers found"
         assert "mcp" in out.lower() or "no MCP servers found" in out or "id" in out.lower()
 
     def test_list_mcp_with_search(self, test_token, test_endpoint):

--- a/tests/cli/test_mcp.py
+++ b/tests/cli/test_mcp.py
@@ -27,6 +27,13 @@ class TestMcpListParser:
         args = parser.parse_args(["mcp", "list"])
         assert hasattr(args, "_mcp_leaf")
 
+    def test_subcmd_token_endpoint(self, parser):
+        args = parser.parse_args([
+            "mcp", "list", "--token", "tk", "--endpoint", "https://x.cn",
+        ])
+        assert args.subcmd_token == "tk"
+        assert args.subcmd_endpoint == "https://x.cn"
+
     def test_search(self, parser):
         args = parser.parse_args(["mcp", "list", "--search", "weather"])
         assert args.search == "weather"
@@ -71,6 +78,13 @@ class TestMcpInfoParser:
         with pytest.raises(SystemExit):
             parser.parse_args(["mcp", "info"])
 
+    def test_subcmd_token_endpoint(self, parser):
+        args = parser.parse_args([
+            "mcp", "info", "org/srv", "--token", "tk", "--endpoint", "https://x.cn",
+        ])
+        assert args.subcmd_token == "tk"
+        assert args.subcmd_endpoint == "https://x.cn"
+
 
 class TestMcpDeployParser:
     """``ms mcp deploy`` argument parsing."""
@@ -83,6 +97,12 @@ class TestMcpDeployParser:
         with pytest.raises(SystemExit):
             parser.parse_args(["mcp", "deploy"])
 
+    def test_subcmd_token_endpoint(self, parser):
+        args = parser.parse_args([
+            "mcp", "deploy", "org/srv", "--token", "tk", "--endpoint", "https://x.cn",
+        ])
+        assert args.subcmd_token == "tk"
+
 
 class TestMcpUndeployParser:
     """``ms mcp undeploy`` argument parsing."""
@@ -94,6 +114,12 @@ class TestMcpUndeployParser:
     def test_missing_server_id_exits(self, parser):
         with pytest.raises(SystemExit):
             parser.parse_args(["mcp", "undeploy"])
+
+    def test_subcmd_token_endpoint(self, parser):
+        args = parser.parse_args([
+            "mcp", "undeploy", "org/srv", "--token", "tk", "--endpoint", "https://x.cn",
+        ])
+        assert args.subcmd_token == "tk"
 
 
 # ===================================================================

--- a/tests/cli/test_repo.py
+++ b/tests/cli/test_repo.py
@@ -1,4 +1,4 @@
-"""Tests for ``ms repo`` group — real API lifecycle: create → info → list → delete."""
+"""Tests for repo commands (ms create/info/list/delete) — real API lifecycle."""
 from __future__ import annotations
 
 import warnings
@@ -29,7 +29,7 @@ class TestRepoLifecycle:
     def test_01_create_repo(self, test_token, test_endpoint):
         """Create a private model repo."""
         exit_code, out, err = run_cli(
-            ["repo", "create", self.repo_id, "--repo-type", "model", "--visibility", "private"],
+            ["create", self.repo_id, "--repo-type", "model", "--visibility", "private"],
             token=test_token,
             endpoint=test_endpoint,
         )
@@ -41,7 +41,7 @@ class TestRepoLifecycle:
     def test_02_repo_info(self, test_token, test_endpoint):
         """Get repo info shows metadata."""
         exit_code, out, err = run_cli(
-            ["repo", "info", self.repo_id, "--repo-type", "model"],
+            ["info", self.repo_id, "--repo-type", "model"],
             token=test_token,
             endpoint=test_endpoint,
         )
@@ -53,7 +53,7 @@ class TestRepoLifecycle:
     def test_03_repo_list(self, test_token, test_endpoint, test_owner):
         """List repos for the test owner."""
         exit_code, out, err = run_cli(
-            ["repo", "list", "--repo-type", "model", "--owner", test_owner],
+            ["list", "--repo-type", "model", "--owner", test_owner],
             token=test_token,
             endpoint=test_endpoint,
         )
@@ -64,7 +64,7 @@ class TestRepoLifecycle:
     def test_04_delete_repo(self, test_token, test_endpoint):
         """Delete the created repo (currently deprecated — expected to fail)."""
         exit_code, out, err = run_cli(
-            ["repo", "delete", self.repo_id, "--repo-type", "model", "--yes"],
+            ["delete", self.repo_id, "--repo-type", "model", "--yes"],
             token=test_token,
             endpoint=test_endpoint,
         )

--- a/tests/cli/test_repo.py
+++ b/tests/cli/test_repo.py
@@ -96,6 +96,10 @@ class TestCreateParser:
         args = parser.parse_args(["create", "o/r", "--repo-type", "model"])
         assert args.exist_ok is False
 
+    def test_missing_repo_type_exits(self, parser):
+        with pytest.raises(SystemExit):
+            parser.parse_args(["create", "o/r"])
+
     @pytest.mark.parametrize("sdk", ["gradio", "streamlit", "docker", "static"])
     def test_studio_sdk_type(self, parser, sdk):
         args = parser.parse_args(
@@ -204,6 +208,10 @@ class TestListParser:
         assert args.page_number == 1
         assert args.page_size == 10
 
+    def test_missing_repo_type_exits(self, parser):
+        with pytest.raises(SystemExit):
+            parser.parse_args(["list"])
+
 
 class TestDeleteParser:
     """``ms delete`` argument parsing."""
@@ -296,6 +304,28 @@ class TestCreateExecute:
         with patch("modelscope_hub.cli.repo.make_api", return_value=mock_api):
             with pytest.raises(Exception, match="already exists"):
                 CreateCommand(args).execute()
+
+    def test_chinese_name_and_description_forwarded(self, parser, mock_api, capsys):
+        args = parser.parse_args([
+            "create", "owner/repo", "--repo-type", "model",
+            "--chinese-name", "测试模型", "--description", "A test model",
+        ])
+        with patch("modelscope_hub.cli.repo.make_api", return_value=mock_api):
+            CreateCommand(args).execute()
+        call_kwargs = mock_api.create_repo.call_args
+        assert call_kwargs.kwargs["chinese_name"] == "测试模型"
+        assert call_kwargs.kwargs["description"] == "A test model"
+
+    def test_base_image_and_cover_image_forwarded(self, parser, mock_api, capsys):
+        args = parser.parse_args([
+            "create", "owner/studio1", "--repo-type", "studio",
+            "--base-image", "python:3.11", "--cover-image", "https://img.png",
+        ])
+        with patch("modelscope_hub.cli.repo.make_api", return_value=mock_api):
+            CreateCommand(args).execute()
+        call_kwargs = mock_api.create_repo.call_args
+        assert call_kwargs.kwargs["base_image"] == "python:3.11"
+        assert call_kwargs.kwargs["cover_image"] == "https://img.png"
 
 
 class TestInfoExecute:

--- a/tests/cli/test_repo.py
+++ b/tests/cli/test_repo.py
@@ -1,13 +1,416 @@
-"""Tests for repo commands (ms create/info/list/delete) — real API lifecycle."""
+"""Tests for repo commands: ms create / info / list / delete.
+
+Includes:
+- Parser tests: verify argparse accepts all documented flags and choices
+- Execution tests: mock HubApi to verify command logic without network
+- Remote tests: real API lifecycle (existing, kept as-is)
+"""
 from __future__ import annotations
 
 import warnings
+from unittest.mock import patch
 
 import pytest
+
+from modelscope_hub.cli.repo import (
+    CreateCommand,
+    DeleteCommand,
+    InfoCommand,
+    ListCommand,
+)
+from modelscope_hub.types import PagedResult
 
 from .conftest import run_cli
 
 
+# ===================================================================
+# Parser tests — no network, no mocks, pure argparse
+# ===================================================================
+class TestCreateParser:
+    """``ms create`` argument parsing."""
+
+    def test_basic(self, parser):
+        args = parser.parse_args(["create", "owner/repo", "--repo-type", "model"])
+        assert args.repo_id == "owner/repo"
+        assert args.repo_type == "model"
+
+    @pytest.mark.parametrize("repo_type", ["model", "dataset", "studio", "skill"])
+    def test_all_repo_types(self, parser, repo_type):
+        args = parser.parse_args(["create", "o/r", "--repo-type", repo_type])
+        assert args.repo_type == repo_type
+
+    def test_invalid_repo_type_rejected(self, parser):
+        with pytest.raises(SystemExit):
+            parser.parse_args(["create", "o/r", "--repo-type", "mcp"])
+
+    @pytest.mark.parametrize("vis", ["public", "private", "internal"])
+    def test_visibility_choices(self, parser, vis):
+        args = parser.parse_args(
+            ["create", "o/r", "--repo-type", "model", "--visibility", vis]
+        )
+        assert args.visibility == vis
+
+    def test_invalid_visibility_rejected(self, parser):
+        with pytest.raises(SystemExit):
+            parser.parse_args(
+                ["create", "o/r", "--repo-type", "model", "--visibility", "secret"]
+            )
+
+    def test_license_flag(self, parser):
+        args = parser.parse_args(
+            ["create", "o/r", "--repo-type", "model", "--license", "apache-2.0"]
+        )
+        assert args.license == "apache-2.0"
+
+    def test_chinese_name(self, parser):
+        args = parser.parse_args(
+            ["create", "o/r", "--repo-type", "model", "--chinese-name", "测试模型"]
+        )
+        assert args.chinese_name == "测试模型"
+
+    def test_chinese_name_underscore(self, parser):
+        args = parser.parse_args(
+            ["create", "o/r", "--repo-type", "model", "--chinese_name", "测试"]
+        )
+        assert args.chinese_name == "测试"
+
+    def test_description(self, parser):
+        args = parser.parse_args(
+            ["create", "o/r", "--repo-type", "model", "--description", "A test model"]
+        )
+        assert args.description == "A test model"
+
+    def test_exist_ok_flag(self, parser):
+        args = parser.parse_args(
+            ["create", "o/r", "--repo-type", "model", "--exist-ok"]
+        )
+        assert args.exist_ok is True
+
+    def test_exist_ok_underscore(self, parser):
+        args = parser.parse_args(
+            ["create", "o/r", "--repo-type", "model", "--exist_ok"]
+        )
+        assert args.exist_ok is True
+
+    def test_exist_ok_default_false(self, parser):
+        args = parser.parse_args(["create", "o/r", "--repo-type", "model"])
+        assert args.exist_ok is False
+
+    @pytest.mark.parametrize("sdk", ["gradio", "streamlit", "docker", "static"])
+    def test_studio_sdk_type(self, parser, sdk):
+        args = parser.parse_args(
+            ["create", "o/r", "--repo-type", "studio", "--sdk-type", sdk]
+        )
+        assert args.sdk_type == sdk
+
+    def test_invalid_sdk_type_rejected(self, parser):
+        with pytest.raises(SystemExit):
+            parser.parse_args(
+                ["create", "o/r", "--repo-type", "studio", "--sdk-type", "flask"]
+            )
+
+    def test_studio_sdk_version(self, parser):
+        args = parser.parse_args(
+            ["create", "o/r", "--repo-type", "studio", "--sdk-version", "4.0"]
+        )
+        assert args.sdk_version == "4.0"
+
+    def test_studio_base_image(self, parser):
+        args = parser.parse_args(
+            ["create", "o/r", "--repo-type", "studio", "--base-image", "python:3.11"]
+        )
+        assert args.base_image == "python:3.11"
+
+    def test_studio_cover_image(self, parser):
+        args = parser.parse_args(
+            ["create", "o/r", "--repo-type", "studio", "--cover-image", "https://img.png"]
+        )
+        assert args.cover_image == "https://img.png"
+
+    def test_studio_hardware(self, parser):
+        args = parser.parse_args(
+            ["create", "o/r", "--repo-type", "studio", "--hardware", "gpu.a10"]
+        )
+        assert args.hardware == "gpu.a10"
+
+    def test_all_studio_options_combined(self, parser):
+        args = parser.parse_args([
+            "create", "o/studio1", "--repo-type", "studio",
+            "--visibility", "private",
+            "--sdk-type", "gradio", "--sdk-version", "4.0",
+            "--base-image", "python:3.11",
+            "--cover-image", "https://img.png",
+            "--hardware", "gpu.a10",
+            "--license", "mit",
+            "--description", "demo",
+            "--chinese-name", "演示",
+        ])
+        assert args.repo_type == "studio"
+        assert args.sdk_type == "gradio"
+        assert args.sdk_version == "4.0"
+        assert args.hardware == "gpu.a10"
+
+
+class TestInfoParser:
+    """``ms info`` argument parsing."""
+
+    def test_basic(self, parser):
+        args = parser.parse_args(["info", "owner/repo", "--repo-type", "model"])
+        assert args.repo_id == "owner/repo"
+        assert args.repo_type == "model"
+
+    @pytest.mark.parametrize("repo_type", ["model", "dataset", "studio", "skill", "mcp"])
+    def test_all_repo_types(self, parser, repo_type):
+        args = parser.parse_args(["info", "o/r", "--repo-type", repo_type])
+        assert args.repo_type == repo_type
+
+    def test_repo_type_required(self, parser):
+        with pytest.raises(SystemExit):
+            parser.parse_args(["info", "o/r"])
+
+
+class TestListParser:
+    """``ms list`` argument parsing."""
+
+    @pytest.mark.parametrize("repo_type", ["model", "dataset", "skill", "mcp"])
+    def test_all_repo_types(self, parser, repo_type):
+        args = parser.parse_args(["list", "--repo-type", repo_type])
+        assert args.repo_type == repo_type
+
+    def test_invalid_repo_type_rejected(self, parser):
+        with pytest.raises(SystemExit):
+            parser.parse_args(["list", "--repo-type", "studio"])
+
+    def test_owner_flag(self, parser):
+        args = parser.parse_args(["list", "--repo-type", "model", "--owner", "my-org"])
+        assert args.owner == "my-org"
+
+    def test_search_flag(self, parser):
+        args = parser.parse_args(["list", "--repo-type", "model", "--search", "qwen"])
+        assert args.search == "qwen"
+
+    def test_page_flag(self, parser):
+        args = parser.parse_args(["list", "--repo-type", "model", "--page", "3"])
+        assert args.page_number == 3
+
+    def test_page_size_flag(self, parser):
+        args = parser.parse_args(["list", "--repo-type", "model", "--page-size", "20"])
+        assert args.page_size == 20
+
+    def test_defaults(self, parser):
+        args = parser.parse_args(["list", "--repo-type", "model"])
+        assert args.owner is None
+        assert args.search is None
+        assert args.page_number == 1
+        assert args.page_size == 10
+
+
+class TestDeleteParser:
+    """``ms delete`` argument parsing."""
+
+    def test_basic(self, parser):
+        args = parser.parse_args(["delete", "owner/repo", "--repo-type", "model"])
+        assert args.repo_id == "owner/repo"
+        assert args.repo_type == "model"
+
+    @pytest.mark.parametrize("repo_type", ["model", "dataset"])
+    def test_valid_repo_types(self, parser, repo_type):
+        args = parser.parse_args(["delete", "o/r", "--repo-type", repo_type])
+        assert args.repo_type == repo_type
+
+    def test_invalid_repo_type_rejected(self, parser):
+        with pytest.raises(SystemExit):
+            parser.parse_args(["delete", "o/r", "--repo-type", "studio"])
+
+    def test_yes_flag(self, parser):
+        args = parser.parse_args(["delete", "o/r", "--repo-type", "model", "--yes"])
+        assert args.yes is True
+
+    def test_yes_short_flag(self, parser):
+        args = parser.parse_args(["delete", "o/r", "--repo-type", "model", "-y"])
+        assert args.yes is True
+
+    def test_yes_default_false(self, parser):
+        args = parser.parse_args(["delete", "o/r", "--repo-type", "model"])
+        assert args.yes is False
+
+
+# ===================================================================
+# Execution tests — mock HubApi, verify command logic
+# ===================================================================
+class TestCreateExecute:
+    """CreateCommand.execute() logic."""
+
+    def test_create_model(self, parser, mock_api, capsys):
+        args = parser.parse_args([
+            "create", "owner/my-model", "--repo-type", "model",
+            "--visibility", "private", "--license", "apache-2.0",
+        ])
+        with patch("modelscope_hub.cli.repo.make_api", return_value=mock_api):
+            CreateCommand(args).execute()
+        mock_api.create_repo.assert_called_once_with(
+            "owner/my-model", "model",
+            visibility="private", license="apache-2.0",
+            chinese_name=None, description=None,
+        )
+        out = capsys.readouterr().out
+        assert "Created" in out
+
+    def test_create_studio_with_extras(self, parser, mock_api, capsys):
+        args = parser.parse_args([
+            "create", "owner/demo", "--repo-type", "studio",
+            "--sdk-type", "gradio", "--sdk-version", "4.0",
+            "--hardware", "gpu.a10",
+        ])
+        with patch("modelscope_hub.cli.repo.make_api", return_value=mock_api):
+            CreateCommand(args).execute()
+        call_kwargs = mock_api.create_repo.call_args
+        assert call_kwargs.kwargs["sdk_type"] == "gradio"
+        assert call_kwargs.kwargs["sdk_version"] == "4.0"
+        assert call_kwargs.kwargs["hardware"] == "gpu.a10"
+
+    def test_exist_ok_swallows_exist_error(self, parser, mock_api, capsys):
+        mock_api.create_repo.side_effect = Exception("Repository already exists")
+        args = parser.parse_args([
+            "create", "owner/repo", "--repo-type", "model", "--exist-ok",
+        ])
+        with patch("modelscope_hub.cli.repo.make_api", return_value=mock_api):
+            CreateCommand(args).execute()
+        out = capsys.readouterr().out
+        assert "already exists" in out
+
+    def test_exist_ok_reraises_non_exist_error(self, parser, mock_api):
+        mock_api.create_repo.side_effect = Exception("Permission denied")
+        args = parser.parse_args([
+            "create", "owner/repo", "--repo-type", "model", "--exist-ok",
+        ])
+        with patch("modelscope_hub.cli.repo.make_api", return_value=mock_api):
+            with pytest.raises(Exception, match="Permission denied"):
+                CreateCommand(args).execute()
+
+    def test_create_without_exist_ok_raises(self, parser, mock_api):
+        mock_api.create_repo.side_effect = Exception("Repository already exists")
+        args = parser.parse_args([
+            "create", "owner/repo", "--repo-type", "model",
+        ])
+        with patch("modelscope_hub.cli.repo.make_api", return_value=mock_api):
+            with pytest.raises(Exception, match="already exists"):
+                CreateCommand(args).execute()
+
+
+class TestInfoExecute:
+    """InfoCommand.execute() logic."""
+
+    def test_info_prints_repo(self, parser, mock_api, capsys):
+        args = parser.parse_args(["info", "owner/repo", "--repo-type", "model"])
+        with patch("modelscope_hub.cli.repo.make_api", return_value=mock_api):
+            InfoCommand(args).execute()
+        mock_api.get_repo.assert_called_once_with("owner/repo", "model")
+        out = capsys.readouterr().out
+        assert "repo_type" in out
+        assert "license" in out
+
+
+class TestListExecute:
+    """ListCommand.execute() logic."""
+
+    def test_list_with_results(self, parser, mock_api, capsys):
+        args = parser.parse_args([
+            "list", "--repo-type", "model", "--owner", "org", "--page-size", "20",
+        ])
+        with patch("modelscope_hub.cli.repo.make_api", return_value=mock_api):
+            ListCommand(args).execute()
+        mock_api.list_repos.assert_called_once_with(
+            "model", owner="org", search=None, page_number=1, page_size=20,
+        )
+        out = capsys.readouterr().out
+        assert "owner/model1" in out
+
+    def test_list_empty(self, parser, mock_api, capsys):
+        mock_api.list_repos.return_value = PagedResult(
+            items=[], total_count=0, page_number=1, page_size=10,
+        )
+        args = parser.parse_args(["list", "--repo-type", "model"])
+        with patch("modelscope_hub.cli.repo.make_api", return_value=mock_api):
+            ListCommand(args).execute()
+        out = capsys.readouterr().out
+        assert "no repositories found" in out
+
+    def test_list_with_search(self, parser, mock_api, capsys):
+        args = parser.parse_args([
+            "list", "--repo-type", "dataset", "--search", "qwen",
+        ])
+        with patch("modelscope_hub.cli.repo.make_api", return_value=mock_api):
+            ListCommand(args).execute()
+        mock_api.list_repos.assert_called_once_with(
+            "dataset", owner=None, search="qwen", page_number=1, page_size=10,
+        )
+
+
+class TestDeleteExecute:
+    """DeleteCommand.execute() logic."""
+
+    def test_delete_with_yes(self, parser, mock_api, capsys):
+        args = parser.parse_args([
+            "delete", "owner/repo", "--repo-type", "model", "--yes",
+        ])
+        with patch("modelscope_hub.cli.repo.make_api", return_value=mock_api):
+            DeleteCommand(args).execute()
+        mock_api.delete_repo.assert_called_once_with("owner/repo", "model")
+        out = capsys.readouterr().out
+        assert "Deleted" in out
+
+    def test_delete_aborted(self, parser, mock_api, capsys):
+        args = parser.parse_args(["delete", "owner/repo", "--repo-type", "model"])
+        with (
+            patch("modelscope_hub.cli.repo.make_api", return_value=mock_api),
+            patch("builtins.input", return_value="n"),
+        ):
+            DeleteCommand(args).execute()
+        mock_api.delete_repo.assert_not_called()
+        out = capsys.readouterr().out
+        assert "Aborted" in out
+
+    def test_delete_confirmed_interactively(self, parser, mock_api, capsys):
+        args = parser.parse_args(["delete", "owner/repo", "--repo-type", "model"])
+        with (
+            patch("modelscope_hub.cli.repo.make_api", return_value=mock_api),
+            patch("builtins.input", return_value="y"),
+        ):
+            DeleteCommand(args).execute()
+        mock_api.delete_repo.assert_called_once()
+
+
+# ===================================================================
+# Backward compat: ``ms repo <action>``
+# ===================================================================
+class TestRepoCompat:
+    """Verify ``ms repo create/info/list/delete`` still works."""
+
+    def test_repo_create(self, parser):
+        args = parser.parse_args([
+            "repo", "create", "o/r", "--repo-type", "model", "--exist-ok",
+        ])
+        assert args.repo_id == "o/r"
+        assert args.exist_ok is True
+
+    def test_repo_info(self, parser):
+        args = parser.parse_args(["repo", "info", "o/r", "--repo-type", "model"])
+        assert args.repo_id == "o/r"
+
+    def test_repo_list(self, parser):
+        args = parser.parse_args(["repo", "list", "--repo-type", "model"])
+        assert args.repo_type == "model"
+
+    def test_repo_delete(self, parser):
+        args = parser.parse_args(["repo", "delete", "o/r", "--repo-type", "model", "--yes"])
+        assert args.repo_id == "o/r"
+        assert args.yes is True
+
+
+# ===================================================================
+# Remote integration tests (existing — require API credentials)
+# ===================================================================
 @pytest.mark.remote
 class TestRepoLifecycle:
     """Test repo CRUD operations with real API."""

--- a/tests/cli/test_repo.py
+++ b/tests/cli/test_repo.py
@@ -154,6 +154,12 @@ class TestCreateParser:
         assert args.sdk_version == "4.0"
         assert args.hardware == "gpu.a10"
 
+    def test_subcmd_token_endpoint(self, parser):
+        args = parser.parse_args([
+            "create", "o/r", "--repo-type", "model", "--token", "tk",
+        ])
+        assert args.subcmd_token == "tk"
+
 
 class TestInfoParser:
     """``ms info`` argument parsing."""
@@ -171,6 +177,13 @@ class TestInfoParser:
     def test_repo_type_required(self, parser):
         with pytest.raises(SystemExit):
             parser.parse_args(["info", "o/r"])
+
+    def test_subcmd_token_endpoint(self, parser):
+        args = parser.parse_args([
+            "info", "o/r", "--repo-type", "model", "--token", "tk", "--endpoint", "https://x.cn",
+        ])
+        assert args.subcmd_token == "tk"
+        assert args.subcmd_endpoint == "https://x.cn"
 
 
 class TestListParser:
@@ -212,6 +225,12 @@ class TestListParser:
         with pytest.raises(SystemExit):
             parser.parse_args(["list"])
 
+    def test_subcmd_token_endpoint(self, parser):
+        args = parser.parse_args([
+            "list", "--repo-type", "model", "--token", "tk",
+        ])
+        assert args.subcmd_token == "tk"
+
 
 class TestDeleteParser:
     """``ms delete`` argument parsing."""
@@ -241,6 +260,12 @@ class TestDeleteParser:
     def test_yes_default_false(self, parser):
         args = parser.parse_args(["delete", "o/r", "--repo-type", "model"])
         assert args.yes is False
+
+    def test_subcmd_token_endpoint(self, parser):
+        args = parser.parse_args([
+            "delete", "o/r", "--repo-type", "model", "--token", "tk",
+        ])
+        assert args.subcmd_token == "tk"
 
 
 # ===================================================================

--- a/tests/cli/test_repo.py
+++ b/tests/cli/test_repo.py
@@ -246,6 +246,7 @@ class TestDeleteParser:
 # ===================================================================
 # Execution tests — mock HubApi, verify command logic
 # ===================================================================
+@pytest.mark.mock_only
 class TestCreateExecute:
     """CreateCommand.execute() logic."""
 
@@ -327,7 +328,53 @@ class TestCreateExecute:
         assert call_kwargs.kwargs["base_image"] == "python:3.11"
         assert call_kwargs.kwargs["cover_image"] == "https://img.png"
 
+    def test_create_dataset(self, parser, mock_api, capsys):
+        """Create a dataset repo via CLI."""
+        args = parser.parse_args([
+            "create", "owner/my-dataset", "--repo-type", "dataset",
+            "--visibility", "private", "--license", "cc-by-4.0",
+            "--description", "Test dataset",
+        ])
+        with patch("modelscope_hub.cli.repo.make_api", return_value=mock_api):
+            CreateCommand(args).execute()
+        mock_api.create_repo.assert_called_once_with(
+            "owner/my-dataset", "dataset",
+            visibility="private", license="cc-by-4.0",
+            chinese_name=None, description="Test dataset",
+        )
+        out = capsys.readouterr().out
+        assert "Created" in out
 
+    def test_create_dataset_public_with_license(self, parser, mock_api, capsys):
+        """Create a public dataset with specific license."""
+        args = parser.parse_args([
+            "create", "owner/public-ds", "--repo-type", "dataset",
+            "--visibility", "public", "--license", "mit",
+        ])
+        with patch("modelscope_hub.cli.repo.make_api", return_value=mock_api):
+            CreateCommand(args).execute()
+        call_kwargs = mock_api.create_repo.call_args
+        assert call_kwargs[0][1] == "dataset"  # repo_type positional arg
+        assert call_kwargs.kwargs["visibility"] == "public"
+        assert call_kwargs.kwargs["license"] == "mit"
+
+    def test_create_dataset_with_chinese_name(self, parser, mock_api, capsys):
+        """Create a dataset with chinese name and description."""
+        args = parser.parse_args([
+            "create", "owner/cn-dataset", "--repo-type", "dataset",
+            "--chinese-name", "测试数据集",
+            "--description", "这是一个测试数据集",
+        ])
+        with patch("modelscope_hub.cli.repo.make_api", return_value=mock_api):
+            CreateCommand(args).execute()
+        mock_api.create_repo.assert_called_once_with(
+            "owner/cn-dataset", "dataset",
+            visibility=None, license=None,
+            chinese_name="测试数据集", description="这是一个测试数据集",
+        )
+
+
+@pytest.mark.mock_only
 class TestInfoExecute:
     """InfoCommand.execute() logic."""
 
@@ -341,6 +388,7 @@ class TestInfoExecute:
         assert "license" in out
 
 
+@pytest.mark.mock_only
 class TestListExecute:
     """ListCommand.execute() logic."""
 
@@ -377,6 +425,7 @@ class TestListExecute:
         )
 
 
+@pytest.mark.mock_only
 class TestDeleteExecute:
     """DeleteCommand.execute() logic."""
 
@@ -439,7 +488,7 @@ class TestRepoCompat:
 
 
 # ===================================================================
-# Remote integration tests (existing — require API credentials)
+# Remote integration tests (require API credentials)
 # ===================================================================
 @pytest.mark.remote
 class TestRepoLifecycle:
@@ -504,5 +553,72 @@ class TestRepoLifecycle:
         print(f"\n** [repo delete] repo_id={self.repo_id}")
         print(f"** exit_code={exit_code}, out={out!r}, err={err!r}")
         # delete_repo is deprecated; hub rejects token-based deletion for now
+        if exit_code != 0:
+            pytest.skip("delete_repo not yet supported via SDK token — clean up via web console")
+
+
+@pytest.mark.remote
+class TestDatasetRepoLifecycle:
+    """Test dataset repo CRUD via CLI with real API."""
+
+    @pytest.fixture(autouse=True, scope="class")
+    def setup_repo(self, api, test_owner, repo_name):
+        """Store dataset repo metadata for tests; cleanup at end."""
+        cls = type(self)
+        cls.repo_id = f"{test_owner}/{repo_name}_ds"
+        cls.api = api
+        cls.test_owner = test_owner
+        yield
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            try:
+                api.delete_repo(cls.repo_id, "dataset")
+            except Exception:
+                pass
+
+    def test_01_create_dataset(self, test_token, test_endpoint):
+        """Create a private dataset repo via CLI."""
+        exit_code, out, err = run_cli(
+            ["create", self.repo_id, "--repo-type", "dataset", "--visibility", "private"],
+            token=test_token,
+            endpoint=test_endpoint,
+        )
+        print(f"\n** [dataset create] repo_id={self.repo_id}")
+        print(f"** exit_code={exit_code}, out={out!r}, err={err!r}")
+        assert exit_code == 0
+        assert "Created" in out
+
+    def test_02_info_dataset(self, test_token, test_endpoint):
+        """Get dataset info."""
+        exit_code, out, err = run_cli(
+            ["info", self.repo_id, "--repo-type", "dataset"],
+            token=test_token,
+            endpoint=test_endpoint,
+        )
+        print(f"\n** [dataset info] repo_id={self.repo_id}")
+        print(f"** exit_code={exit_code}, out={out!r}, err={err!r}")
+        assert exit_code == 0
+        assert "repo_id" in out or self.repo_id in out
+
+    def test_03_list_datasets(self, test_token, test_endpoint):
+        """List datasets should include created one."""
+        exit_code, out, err = run_cli(
+            ["list", "--repo-type", "dataset", "--owner", self.test_owner],
+            token=test_token,
+            endpoint=test_endpoint,
+        )
+        print(f"\n** [dataset list] owner={self.test_owner}")
+        print(f"** exit_code={exit_code}, out={out[:200]!r}, err={err!r}")
+        assert exit_code == 0
+
+    def test_04_delete_dataset(self, test_token, test_endpoint):
+        """Delete the dataset repo."""
+        exit_code, out, err = run_cli(
+            ["delete", self.repo_id, "--repo-type", "dataset", "--yes"],
+            token=test_token,
+            endpoint=test_endpoint,
+        )
+        print(f"\n** [dataset delete] repo_id={self.repo_id}")
+        print(f"** exit_code={exit_code}, out={out!r}, err={err!r}")
         if exit_code != 0:
             pytest.skip("delete_repo not yet supported via SDK token — clean up via web console")

--- a/tests/cli/test_secret.py
+++ b/tests/cli/test_secret.py
@@ -52,6 +52,12 @@ class TestSecretAddParser:
         ])
         assert args.repo_type == "studio"
 
+    def test_subcmd_token_endpoint(self, parser):
+        args = parser.parse_args([
+            "secret", "add", "o/r", "K", "V", "--token", "tk",
+        ])
+        assert args.subcmd_token == "tk"
+
 
 class TestSecretListParser:
     """``ms secret list`` argument parsing."""

--- a/tests/cli/test_secret.py
+++ b/tests/cli/test_secret.py
@@ -46,6 +46,12 @@ class TestSecretAddParser:
         with pytest.raises(SystemExit):
             parser.parse_args(["secret", "add", "o/r"])
 
+    def test_explicit_repo_type(self, parser):
+        args = parser.parse_args([
+            "secret", "add", "o/r", "K", "V", "--repo-type", "studio",
+        ])
+        assert args.repo_type == "studio"
+
 
 class TestSecretListParser:
     """``ms secret list`` argument parsing."""

--- a/tests/cli/test_secret.py
+++ b/tests/cli/test_secret.py
@@ -1,13 +1,170 @@
-"""Tests for ``ms secret`` group — real API secret CRUD lifecycle."""
+"""Tests for ``ms secret`` group — add / list / update / delete.
+
+Includes:
+- Parser tests: all subcommands and flags
+- Execution tests: mock HubApi for secret CRUD logic
+- Remote tests: real API lifecycle (existing)
+"""
 from __future__ import annotations
 
 import warnings
+from unittest.mock import patch
 
 import pytest
+
+from modelscope_hub.cli.secret import (
+    _SecretAdd,
+    _SecretDelete,
+    _SecretList,
+    _SecretUpdate,
+)
 
 from .conftest import run_cli
 
 
+# ===================================================================
+# Parser tests
+# ===================================================================
+class TestSecretAddParser:
+    """``ms secret add`` argument parsing."""
+
+    def test_basic(self, parser):
+        args = parser.parse_args(["secret", "add", "org/demo", "API_KEY", "sk-xxx"])
+        assert args.repo_id == "org/demo"
+        assert args.key == "API_KEY"
+        assert args.value == "sk-xxx"
+
+    def test_repo_type_default_studio(self, parser):
+        args = parser.parse_args(["secret", "add", "o/r", "K", "V"])
+        assert args.repo_type == "studio"
+
+    def test_missing_value_exits(self, parser):
+        with pytest.raises(SystemExit):
+            parser.parse_args(["secret", "add", "o/r", "K"])
+
+    def test_missing_key_and_value_exits(self, parser):
+        with pytest.raises(SystemExit):
+            parser.parse_args(["secret", "add", "o/r"])
+
+
+class TestSecretListParser:
+    """``ms secret list`` argument parsing."""
+
+    def test_basic(self, parser):
+        args = parser.parse_args(["secret", "list", "org/demo"])
+        assert args.repo_id == "org/demo"
+
+    def test_repo_type_default_studio(self, parser):
+        args = parser.parse_args(["secret", "list", "o/r"])
+        assert args.repo_type == "studio"
+
+
+class TestSecretUpdateParser:
+    """``ms secret update`` argument parsing."""
+
+    def test_basic(self, parser):
+        args = parser.parse_args(["secret", "update", "org/demo", "KEY", "new_val"])
+        assert args.repo_id == "org/demo"
+        assert args.key == "KEY"
+        assert args.value == "new_val"
+
+
+class TestSecretDeleteParser:
+    """``ms secret delete`` argument parsing."""
+
+    def test_basic(self, parser):
+        args = parser.parse_args(["secret", "delete", "org/demo", "KEY"])
+        assert args.repo_id == "org/demo"
+        assert args.key == "KEY"
+
+    def test_yes_flag(self, parser):
+        args = parser.parse_args(["secret", "delete", "o/r", "K", "--yes"])
+        assert args.yes is True
+
+    def test_yes_short(self, parser):
+        args = parser.parse_args(["secret", "delete", "o/r", "K", "-y"])
+        assert args.yes is True
+
+    def test_yes_default_false(self, parser):
+        args = parser.parse_args(["secret", "delete", "o/r", "K"])
+        assert args.yes is False
+
+
+# ===================================================================
+# Execution tests — mock HubApi
+# ===================================================================
+class TestSecretAddExecute:
+    def test_add_secret(self, parser, mock_api, capsys):
+        args = parser.parse_args(["secret", "add", "org/demo", "API_KEY", "sk-xxx"])
+        with patch("modelscope_hub.cli.secret.make_api", return_value=mock_api):
+            _SecretAdd(args).execute()
+        mock_api.add_secret.assert_called_once_with("org/demo", "API_KEY", "sk-xxx", "studio")
+        out = capsys.readouterr().out
+        assert "Added" in out
+        assert "API_KEY" in out
+
+
+class TestSecretListExecute:
+    def test_list_with_secrets(self, parser, mock_api, capsys):
+        args = parser.parse_args(["secret", "list", "org/demo"])
+        with patch("modelscope_hub.cli.secret.make_api", return_value=mock_api):
+            _SecretList(args).execute()
+        mock_api.list_secrets.assert_called_once_with("org/demo", "studio")
+        out = capsys.readouterr().out
+        assert "API_KEY" in out
+
+    def test_list_empty(self, parser, mock_api, capsys):
+        mock_api.list_secrets.return_value = []
+        args = parser.parse_args(["secret", "list", "org/demo"])
+        with patch("modelscope_hub.cli.secret.make_api", return_value=mock_api):
+            _SecretList(args).execute()
+        out = capsys.readouterr().out
+        assert "no secrets" in out
+
+
+class TestSecretUpdateExecute:
+    def test_update_secret(self, parser, mock_api, capsys):
+        args = parser.parse_args(["secret", "update", "org/demo", "KEY", "new_val"])
+        with patch("modelscope_hub.cli.secret.make_api", return_value=mock_api):
+            _SecretUpdate(args).execute()
+        mock_api.update_secret.assert_called_once_with("org/demo", "KEY", "new_val", "studio")
+        out = capsys.readouterr().out
+        assert "Updated" in out
+
+
+class TestSecretDeleteExecute:
+    def test_delete_with_yes(self, parser, mock_api, capsys):
+        args = parser.parse_args(["secret", "delete", "org/demo", "KEY", "--yes"])
+        with patch("modelscope_hub.cli.secret.make_api", return_value=mock_api):
+            _SecretDelete(args).execute()
+        mock_api.delete_secret.assert_called_once_with("org/demo", "KEY", "studio")
+        out = capsys.readouterr().out
+        assert "Deleted" in out
+
+    def test_delete_aborted(self, parser, mock_api, capsys):
+        args = parser.parse_args(["secret", "delete", "org/demo", "KEY"])
+        with (
+            patch("modelscope_hub.cli.secret.make_api", return_value=mock_api),
+            patch("builtins.input", return_value="n"),
+        ):
+            _SecretDelete(args).execute()
+        mock_api.delete_secret.assert_not_called()
+        out = capsys.readouterr().out
+        assert "Aborted" in out
+
+    def test_delete_confirmed_interactively(self, parser, mock_api, capsys):
+        args = parser.parse_args(["secret", "delete", "org/demo", "KEY"])
+        with (
+            patch("modelscope_hub.cli.secret.make_api", return_value=mock_api),
+            patch("builtins.input", return_value="y"),
+        ):
+            _SecretDelete(args).execute()
+        mock_api.delete_secret.assert_called_once()
+
+
+# ===================================================================
+# Remote integration tests (existing)
+# ===================================================================
 @pytest.mark.remote
 class TestSecretLifecycle:
     """Test secret CRUD operations with real API on a studio repo."""

--- a/tests/cli/test_secret.py
+++ b/tests/cli/test_secret.py
@@ -99,6 +99,7 @@ class TestSecretDeleteParser:
 # ===================================================================
 # Execution tests — mock HubApi
 # ===================================================================
+@pytest.mark.mock_only
 class TestSecretAddExecute:
     def test_add_secret(self, parser, mock_api, capsys):
         args = parser.parse_args(["secret", "add", "org/demo", "API_KEY", "sk-xxx"])
@@ -110,6 +111,7 @@ class TestSecretAddExecute:
         assert "API_KEY" in out
 
 
+@pytest.mark.mock_only
 class TestSecretListExecute:
     def test_list_with_secrets(self, parser, mock_api, capsys):
         args = parser.parse_args(["secret", "list", "org/demo"])
@@ -128,6 +130,7 @@ class TestSecretListExecute:
         assert "no secrets" in out
 
 
+@pytest.mark.mock_only
 class TestSecretUpdateExecute:
     def test_update_secret(self, parser, mock_api, capsys):
         args = parser.parse_args(["secret", "update", "org/demo", "KEY", "new_val"])
@@ -138,6 +141,7 @@ class TestSecretUpdateExecute:
         assert "Updated" in out
 
 
+@pytest.mark.mock_only
 class TestSecretDeleteExecute:
     def test_delete_with_yes(self, parser, mock_api, capsys):
         args = parser.parse_args(["secret", "delete", "org/demo", "KEY", "--yes"])

--- a/tests/cli/test_upload.py
+++ b/tests/cli/test_upload.py
@@ -1,13 +1,218 @@
-"""Tests for ``ms upload`` command — real API file and folder upload."""
+"""Tests for ``ms upload`` command.
+
+Includes:
+- Parser tests: all flags and choices
+- Execution tests: mock HubApi for file/folder upload logic
+- Remote tests: real API upload (existing)
+"""
 from __future__ import annotations
 
 import warnings
+from pathlib import Path
+from unittest.mock import patch
 
 import pytest
+
+from modelscope_hub.cli.upload import UploadCommand
 
 from .conftest import run_cli
 
 
+# ===================================================================
+# Parser tests
+# ===================================================================
+class TestUploadParser:
+    """``ms upload`` argument parsing."""
+
+    def test_basic(self, parser):
+        args = parser.parse_args(["upload", "owner/repo", "./weights.bin"])
+        assert args.repo_id == "owner/repo"
+        assert args.local_path == "./weights.bin"
+
+    def test_with_path_in_repo(self, parser):
+        args = parser.parse_args(["upload", "owner/repo", "./output", "models/"])
+        assert args.local_path == "./output"
+        assert args.path_in_repo == "models/"
+
+    def test_repo_type_default_model(self, parser):
+        args = parser.parse_args(["upload", "owner/repo", "."])
+        assert args.repo_type == "model"
+
+    @pytest.mark.parametrize("repo_type", ["model", "dataset"])
+    def test_repo_type_choices(self, parser, repo_type):
+        args = parser.parse_args(["upload", "o/r", ".", "--repo-type", repo_type])
+        assert args.repo_type == repo_type
+
+    def test_invalid_repo_type_rejected(self, parser):
+        with pytest.raises(SystemExit):
+            parser.parse_args(["upload", "o/r", ".", "--repo-type", "studio"])
+
+    def test_commit_message(self, parser):
+        args = parser.parse_args([
+            "upload", "o/r", ".", "--commit-message", "add weights",
+        ])
+        assert args.commit_message == "add weights"
+
+    def test_commit_description(self, parser):
+        args = parser.parse_args([
+            "upload", "o/r", ".", "--commit-description", "extended desc",
+        ])
+        assert args.commit_description == "extended desc"
+
+    def test_revision(self, parser):
+        args = parser.parse_args(["upload", "o/r", ".", "--revision", "dev"])
+        assert args.revision == "dev"
+
+    def test_include_patterns(self, parser):
+        args = parser.parse_args(["upload", "o/r", ".", "--include", "*.py", "*.txt"])
+        assert args.allow_patterns == ["*.py", "*.txt"]
+
+    def test_exclude_patterns(self, parser):
+        args = parser.parse_args(["upload", "o/r", ".", "--exclude", "*.ckpt", "*.bin"])
+        assert args.ignore_patterns == ["*.ckpt", "*.bin"]
+
+    def test_max_workers(self, parser):
+        args = parser.parse_args(["upload", "o/r", ".", "--max-workers", "8"])
+        assert args.max_workers == 8
+
+    def test_max_workers_default_none(self, parser):
+        args = parser.parse_args(["upload", "o/r", "."])
+        assert args.max_workers is None
+
+    def test_use_cache_default_true(self, parser):
+        args = parser.parse_args(["upload", "o/r", "."])
+        assert args.use_cache is True
+
+    def test_no_cache(self, parser):
+        args = parser.parse_args(["upload", "o/r", ".", "--no-cache"])
+        assert args.use_cache is False
+
+    def test_use_cache_explicit(self, parser):
+        args = parser.parse_args(["upload", "o/r", ".", "--use-cache"])
+        assert args.use_cache is True
+
+    def test_disable_tqdm(self, parser):
+        args = parser.parse_args(["upload", "o/r", ".", "--disable-tqdm"])
+        assert args.disable_tqdm is True
+
+    def test_disable_tqdm_default_false(self, parser):
+        args = parser.parse_args(["upload", "o/r", "."])
+        assert args.disable_tqdm is False
+
+    def test_subcmd_token_endpoint(self, parser):
+        args = parser.parse_args([
+            "upload", "o/r", ".",
+            "--token", "ms-tok", "--endpoint", "https://x.cn",
+        ])
+        assert args.subcmd_token == "ms-tok"
+        assert args.subcmd_endpoint == "https://x.cn"
+
+    def test_all_options_combined(self, parser):
+        args = parser.parse_args([
+            "upload", "my-org/my-model", "./output", "weights/",
+            "--repo-type", "dataset",
+            "--commit-message", "v2",
+            "--commit-description", "retrained",
+            "--revision", "dev",
+            "--include", "*.safetensors",
+            "--exclude", "*.ckpt",
+            "--max-workers", "4",
+            "--no-cache",
+            "--disable-tqdm",
+        ])
+        assert args.repo_id == "my-org/my-model"
+        assert args.local_path == "./output"
+        assert args.path_in_repo == "weights/"
+        assert args.repo_type == "dataset"
+        assert args.use_cache is False
+        assert args.disable_tqdm is True
+
+
+# ===================================================================
+# Execution tests — mock HubApi
+# ===================================================================
+class TestUploadExecute:
+    """UploadCommand.execute() logic with mocked API."""
+
+    def test_file_upload(self, parser, mock_api, tmp_path, capsys):
+        test_file = tmp_path / "weights.bin"
+        test_file.write_text("content")
+        args = parser.parse_args(["upload", "owner/repo", str(test_file)])
+        with patch("modelscope_hub.cli.upload.make_api", return_value=mock_api):
+            UploadCommand(args).execute()
+        mock_api.upload_file.assert_called_once()
+        call_args = mock_api.upload_file.call_args
+        assert call_args.args[0] == "owner/repo"
+        assert call_args.args[3] == "weights.bin"
+        out = capsys.readouterr().out
+        assert "Upload complete" in out
+
+    def test_folder_upload(self, parser, mock_api, tmp_path, capsys):
+        upload_dir = tmp_path / "output"
+        upload_dir.mkdir()
+        (upload_dir / "a.txt").write_text("a")
+        args = parser.parse_args(["upload", "owner/repo", str(upload_dir)])
+        with patch("modelscope_hub.cli.upload.make_api", return_value=mock_api):
+            UploadCommand(args).execute()
+        mock_api.upload_folder.assert_called_once()
+        out = capsys.readouterr().out
+        assert "Folder upload complete" in out
+
+    def test_folder_upload_nothing_to_upload(self, parser, mock_api, tmp_path, capsys):
+        upload_dir = tmp_path / "empty_dir"
+        upload_dir.mkdir()
+        (upload_dir / "a.txt").write_text("a")
+        mock_api.upload_folder.return_value = None
+        args = parser.parse_args(["upload", "owner/repo", str(upload_dir)])
+        with patch("modelscope_hub.cli.upload.make_api", return_value=mock_api):
+            UploadCommand(args).execute()
+        out = capsys.readouterr().out
+        assert "nothing to upload" in out
+
+    def test_nonexistent_path_exits_2(self, parser, mock_api, capsys):
+        args = parser.parse_args(["upload", "owner/repo", "/nonexistent/path"])
+        with patch("modelscope_hub.cli.upload.make_api", return_value=mock_api):
+            with pytest.raises(SystemExit) as exc_info:
+                UploadCommand(args).execute()
+            assert exc_info.value.code == 2
+
+    def test_no_cache_forwarded(self, parser, mock_api, tmp_path, capsys):
+        upload_dir = tmp_path / "dir"
+        upload_dir.mkdir()
+        (upload_dir / "f.txt").write_text("x")
+        args = parser.parse_args(["upload", "o/r", str(upload_dir), "--no-cache"])
+        with patch("modelscope_hub.cli.upload.make_api", return_value=mock_api):
+            UploadCommand(args).execute()
+        assert mock_api.upload_folder.call_args.kwargs["use_cache"] is False
+
+    def test_commit_message_forwarded(self, parser, mock_api, tmp_path, capsys):
+        test_file = tmp_path / "f.bin"
+        test_file.write_text("data")
+        args = parser.parse_args([
+            "upload", "o/r", str(test_file),
+            "--commit-message", "add weights",
+            "--commit-description", "desc",
+        ])
+        with patch("modelscope_hub.cli.upload.make_api", return_value=mock_api):
+            UploadCommand(args).execute()
+        kw = mock_api.upload_file.call_args.kwargs
+        assert kw["commit_message"] == "add weights"
+        assert kw["commit_description"] == "desc"
+
+    def test_dataset_upload(self, parser, mock_api, tmp_path, capsys):
+        test_file = tmp_path / "data.csv"
+        test_file.write_text("a,b\n1,2")
+        args = parser.parse_args([
+            "upload", "o/r", str(test_file), "--repo-type", "dataset",
+        ])
+        with patch("modelscope_hub.cli.upload.make_api", return_value=mock_api):
+            UploadCommand(args).execute()
+        assert mock_api.upload_file.call_args.args[1] == "dataset"
+
+
+# ===================================================================
+# Remote integration tests (existing)
+# ===================================================================
 @pytest.mark.remote
 class TestUploadLifecycle:
     """Test file upload with real API on a temporary repo."""

--- a/tests/cli/test_upload.py
+++ b/tests/cli/test_upload.py
@@ -131,6 +131,7 @@ class TestUploadParser:
 # ===================================================================
 # Execution tests — mock HubApi
 # ===================================================================
+@pytest.mark.mock_only
 class TestUploadExecute:
     """UploadCommand.execute() logic with mocked API."""
 

--- a/tests/cli/test_upload.py
+++ b/tests/cli/test_upload.py
@@ -209,6 +209,62 @@ class TestUploadExecute:
             UploadCommand(args).execute()
         assert mock_api.upload_file.call_args.args[1] == "dataset"
 
+    def test_path_in_repo_forwarded(self, parser, mock_api, tmp_path, capsys):
+        test_file = tmp_path / "f.bin"
+        test_file.write_text("data")
+        args = parser.parse_args(["upload", "o/r", str(test_file), "models/"])
+        with patch("modelscope_hub.cli.upload.make_api", return_value=mock_api):
+            UploadCommand(args).execute()
+        assert mock_api.upload_file.call_args.args[3] == "models/"
+
+    def test_include_exclude_forwarded(self, parser, mock_api, tmp_path, capsys):
+        upload_dir = tmp_path / "src"
+        upload_dir.mkdir()
+        (upload_dir / "a.py").write_text("x")
+        args = parser.parse_args([
+            "upload", "o/r", str(upload_dir),
+            "--include", "*.py", "--exclude", "*.pyc",
+        ])
+        with patch("modelscope_hub.cli.upload.make_api", return_value=mock_api):
+            UploadCommand(args).execute()
+        kw = mock_api.upload_folder.call_args.kwargs
+        assert kw["allow_patterns"] == ["*.py"]
+        assert kw["ignore_patterns"] == ["*.pyc"]
+
+    def test_revision_forwarded(self, parser, mock_api, tmp_path, capsys):
+        test_file = tmp_path / "f.bin"
+        test_file.write_text("data")
+        args = parser.parse_args(["upload", "o/r", str(test_file), "--revision", "dev"])
+        with patch("modelscope_hub.cli.upload.make_api", return_value=mock_api):
+            UploadCommand(args).execute()
+        assert mock_api.upload_file.call_args.kwargs["revision"] == "dev"
+
+    def test_max_workers_forwarded(self, parser, mock_api, tmp_path, capsys):
+        upload_dir = tmp_path / "dir"
+        upload_dir.mkdir()
+        (upload_dir / "f.txt").write_text("x")
+        args = parser.parse_args(["upload", "o/r", str(upload_dir), "--max-workers", "4"])
+        with patch("modelscope_hub.cli.upload.make_api", return_value=mock_api):
+            UploadCommand(args).execute()
+        assert mock_api.upload_folder.call_args.kwargs["max_workers"] == 4
+
+    def test_disable_tqdm_forwarded(self, parser, mock_api, tmp_path, capsys):
+        test_file = tmp_path / "f.bin"
+        test_file.write_text("data")
+        args = parser.parse_args(["upload", "o/r", str(test_file), "--disable-tqdm"])
+        with patch("modelscope_hub.cli.upload.make_api", return_value=mock_api):
+            UploadCommand(args).execute()
+        assert mock_api.upload_file.call_args.kwargs["disable_tqdm"] is True
+
+    def test_resolve_paths_no_local_path(self, parser, mock_api, tmp_path, capsys):
+        args = parser.parse_args(["upload", "o/nonexistent"])
+        cmd = UploadCommand(args)
+        with patch("os.path.isfile", return_value=False), \
+             patch("os.path.isdir", return_value=False):
+            local, pir = cmd._resolve_paths()
+        assert local == "."
+        assert pir is None
+
 
 # ===================================================================
 # Remote integration tests (existing)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,25 +29,58 @@ _load_dotenv(Path(__file__).parent / ".env")
 
 
 # ---------------------------------------------------------------------------
+# Remote mode detection
+# ---------------------------------------------------------------------------
+def is_remote_enabled() -> bool:
+    """Check if remote tests should run.
+
+    Returns True (run real API tests) unless MODELSCOPE_RUN_REMOTE_TESTS=false.
+    When the flag is unset, we auto-detect based on valid credentials.
+    """
+    flag = os.environ.get("MODELSCOPE_RUN_REMOTE_TESTS", "").lower()
+    if flag == "false":
+        return False
+    # Explicit opt-in
+    if flag in ("true", "1", "yes"):
+        token = os.environ.get("MODELSCOPE_TEST_TOKEN", "")
+        return bool(token and token != "your_token_here")
+    # Auto-detect: has valid credentials → remote enabled
+    token = os.environ.get("MODELSCOPE_TEST_TOKEN", "")
+    return bool(token and token != "your_token_here")
+
+
+# ---------------------------------------------------------------------------
 # Pytest hooks
 # ---------------------------------------------------------------------------
 def pytest_configure(config):
     config.addinivalue_line("markers", "remote: tests requiring remote API access")
+    config.addinivalue_line("markers", "mock_only: tests using mock API (only run when MODELSCOPE_RUN_REMOTE_TESTS=false)")
 
 
 def pytest_collection_modifyitems(config, items):
-    """Auto-skip remote tests unless explicitly enabled with credentials."""
-    run_remote = os.environ.get("MODELSCOPE_RUN_REMOTE_TESTS", "").lower() in ("true", "1", "yes")
-    token = os.environ.get("MODELSCOPE_TEST_TOKEN")
-    owner = os.environ.get("MODELSCOPE_TEST_OWNER")
-    if run_remote and token and owner and token != "your_token_here":
-        return
-    skip = pytest.mark.skip(
-        reason="Remote tests disabled (set MODELSCOPE_RUN_REMOTE_TESTS=true with valid credentials)"
-    )
-    for item in items:
-        if "remote" in item.keywords:
-            item.add_marker(skip)
+    """Conditionally skip tests based on remote mode.
+
+    - remote_enabled=True  → skip mock_only tests, run remote tests
+    - remote_enabled=False → skip remote tests, run mock_only tests
+    """
+    remote_enabled = is_remote_enabled()
+
+    if remote_enabled:
+        # Skip mock-only tests when real API is available
+        skip_mock = pytest.mark.skip(
+            reason="Mock-only tests skipped (remote mode active)"
+        )
+        for item in items:
+            if "mock_only" in item.keywords:
+                item.add_marker(skip_mock)
+    else:
+        # Skip remote tests when in mock/local mode
+        skip_remote = pytest.mark.skip(
+            reason="Remote tests disabled (set MODELSCOPE_RUN_REMOTE_TESTS=true with valid credentials)"
+        )
+        for item in items:
+            if "remote" in item.keywords:
+                item.add_marker(skip_remote)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,12 +36,15 @@ def pytest_configure(config):
 
 
 def pytest_collection_modifyitems(config, items):
-    """Auto-skip remote tests when credentials are not configured."""
+    """Auto-skip remote tests unless explicitly enabled with credentials."""
+    run_remote = os.environ.get("MODELSCOPE_RUN_REMOTE_TESTS", "").lower() in ("true", "1", "yes")
     token = os.environ.get("MODELSCOPE_TEST_TOKEN")
     owner = os.environ.get("MODELSCOPE_TEST_OWNER")
-    if token and owner and token != "your_token_here":
+    if run_remote and token and owner and token != "your_token_here":
         return
-    skip = pytest.mark.skip(reason="MODELSCOPE_TEST_TOKEN and MODELSCOPE_TEST_OWNER not set")
+    skip = pytest.mark.skip(
+        reason="Remote tests disabled (set MODELSCOPE_RUN_REMOTE_TESTS=true with valid credentials)"
+    )
     for item in items:
         if "remote" in item.keywords:
             item.add_marker(skip)

--- a/tests/integration/test_dataset_ops.py
+++ b/tests/integration/test_dataset_ops.py
@@ -1,0 +1,98 @@
+"""Integration tests for dataset-specific operations.
+
+These tests verify that dataset file listing, download, and CLI operations
+work correctly against the ModelScope API. Datasets use a different file
+listing endpoint (/repo/tree) than models (/repo/files), so they need
+dedicated test coverage.
+
+Uses a known small public dataset — no auth required for read operations.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from modelscope_hub import HubApi
+
+PUBLIC_DATASET_ID = "tencent-community/CL-bench"
+PUBLIC_DATASET_SMALL_FILE = "dataset_infos.json"
+PUBLIC_DATASET_SMALL_FILE_SIZE = 123
+
+
+@pytest.mark.remote
+class TestDatasetFileOperations:
+    """Test list_repo_files, download_file, download_repo for datasets."""
+
+    @pytest.fixture(autouse=True)
+    def setup_api(self, test_endpoint):
+        self.api = HubApi(endpoint=test_endpoint)
+
+    def test_list_repo_files_dataset(self):
+        """list_repo_files works for dataset repos (uses /repo/tree endpoint)."""
+        files = self.api.list_repo_files(PUBLIC_DATASET_ID, "dataset")
+        paths = [f.path for f in files]
+        assert len(paths) > 0
+        assert PUBLIC_DATASET_SMALL_FILE in paths
+
+    def test_download_file_dataset(self, tmp_path):
+        """download_file can fetch a single file from a dataset repo."""
+        local = self.api.download_file(
+            PUBLIC_DATASET_ID,
+            "dataset",
+            PUBLIC_DATASET_SMALL_FILE,
+            local_dir=str(tmp_path),
+            force=True,
+        )
+        assert local.exists()
+        assert local.stat().st_size == PUBLIC_DATASET_SMALL_FILE_SIZE
+
+    def test_download_repo_dataset(self, tmp_path):
+        """download_repo can fetch a dataset snapshot (with pattern filter)."""
+        output = self.api.download_repo(
+            PUBLIC_DATASET_ID,
+            "dataset",
+            local_dir=str(tmp_path / "out"),
+            allow_patterns=["*.json"],
+        )
+        assert output.is_dir()
+        files = [p.name for p in output.rglob("*") if p.is_file()]
+        assert PUBLIC_DATASET_SMALL_FILE in files
+
+
+@pytest.mark.remote
+class TestDatasetCLI:
+    """Test CLI download commands with --repo-type dataset."""
+
+    def test_cli_download_dataset_single_file(self, test_endpoint, tmp_path):
+        """ms download <dataset> <file> --repo-type dataset works."""
+        from tests.cli.conftest import run_cli
+
+        exit_code, out, err = run_cli(
+            [
+                "download", PUBLIC_DATASET_ID,
+                PUBLIC_DATASET_SMALL_FILE,
+                "--repo-type", "dataset",
+                "--local-dir", str(tmp_path),
+            ],
+            endpoint=test_endpoint,
+        )
+        assert exit_code == 0, f"CLI failed: {out} {err}"
+        assert (tmp_path / PUBLIC_DATASET_SMALL_FILE).exists()
+
+    def test_cli_download_dataset_snapshot(self, test_endpoint, tmp_path):
+        """ms download <dataset> --repo-type dataset with pattern filter."""
+        from tests.cli.conftest import run_cli
+
+        exit_code, out, err = run_cli(
+            [
+                "download", PUBLIC_DATASET_ID,
+                "--repo-type", "dataset",
+                "--local-dir", str(tmp_path),
+                "--include", "*.json",
+            ],
+            endpoint=test_endpoint,
+        )
+        assert exit_code == 0, f"CLI failed: {out} {err}"
+        assert "Snapshot ready" in out
+        assert (tmp_path / PUBLIC_DATASET_SMALL_FILE).exists()

--- a/tests/integration/test_sdk_api.py
+++ b/tests/integration/test_sdk_api.py
@@ -43,6 +43,31 @@ class TestRepoManagement:
     def test_repo_exists_returns_false_for_nonexistent(self, api, test_owner):
         assert api.repo_exists(f"{test_owner}/nonexistent_repo_xyz_999", "model") is False
 
+    def test_create_get_delete_dataset(self, api, test_owner, unique_repo_name):
+        """Test dataset CRUD via SDK: create → get → exists → delete."""
+        repo_id = f"{test_owner}/{unique_repo_name}_ds"
+        try:
+            info = api.create_repo(
+                repo_id, "dataset",
+                visibility="private",
+                license="cc-by-4.0",
+            )
+            assert info is not None
+
+            # Verify exists
+            assert api.repo_exists(repo_id, "dataset") is True
+
+            # Get info
+            repo = api.get_repo(repo_id, "dataset")
+            assert repo.owner == test_owner
+        finally:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                try:
+                    api.delete_repo(repo_id, "dataset")
+                except Exception:
+                    pass
+
     def test_list_repos_returns_paged_result(self, api, test_owner):
         result = api.list_repos("model", owner=test_owner, page_size=3)
         assert hasattr(result, "items")


### PR DESCRIPTION

* **CLI Command Promotion:** Promoted `create`, `info`, `list`, and `delete` to top-level commands.
* **Backward Compatibility:** Retained the legacy `repo` command as a hidden alias (implemented via `help=argparse.SUPPRESS` for stability).
* **Dataset Routing Fixes:** Corrected dataset operations to properly route to multipart and `/repo/tree` endpoints.
* **API Enum Support:** Updated endpoint checks in `_legacy_api.py` to properly handle the `RepoType.DATASET` enum.
* **Enhanced Error Reporting:** Added request and response context to error messages for easier debugging.
* **Test Coverage:** Added comprehensive mock-based unit tests.