### PR TITLE
fix: fallback to legacy API for private dataset/model info

### DIFF
--- a/src/modelscope_hub/_legacy_api.py
+++ b/src/modelscope_hub/_legacy_api.py
@@ -239,6 +239,16 @@ class LegacyClient:
             resp = self._request("POST", segment, json_body=body)
         return self._json_data(resp)
 
+    def get_repo_info(self, repo_id: str, repo_type: str) -> dict:
+        """GET /api/v1/{type}s/{repo_id} — fetch repository metadata.
+
+        Uses cookie-based session auth which supports private repositories
+        (unlike the OpenAPI Bearer-only endpoint).
+        """
+        segment = _resolve_segment(repo_type)
+        resp = self._request("GET", f"{segment}/{repo_id}")
+        return self._json_data(resp)
+
     def delete_repo(self, repo_id: str, repo_type: str) -> None:
         """Delete a repository.
 

--- a/src/modelscope_hub/api.py
+++ b/src/modelscope_hub/api.py
@@ -643,9 +643,15 @@ class HubApi:
         owner, name = self._parse_repo_id(repo_id)
 
         if rt is RepoType.MODEL:
-            data = self.openapi.get_model(owner, name)
+            try:
+                data = self.openapi.get_model(owner, name)
+            except NotExistError:
+                data = self.legacy.get_repo_info(repo_id, str(rt))
         elif rt is RepoType.DATASET:
-            data = self.openapi.get_dataset(owner, name)
+            try:
+                data = self.openapi.get_dataset(owner, name)
+            except NotExistError:
+                data = self.legacy.get_repo_info(repo_id, str(rt))
         elif rt is RepoType.STUDIO:
             data = self.openapi.get_studio(owner, name)
         elif rt is RepoType.SKILL:


### PR DESCRIPTION
The OpenAPI GET /datasets/{owner}/{name} endpoint returns 404 for private datasets even with a valid Bearer token. The legacy API with cookie-based session auth handles private repos correctly. Add a fallback: on NotExistError from OpenAPI, retry via the legacy client.