### PR TITLE
Add cache checksum verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,8 @@ Inspect and clean the local download cache.
 ```bash
 ms cache scan
 ms cache scan --cache-dir /data/cache
+ms cache verify Qwen/Qwen3-0.6B
+ms cache verify Qwen/Qwen3-0.6B --local-dir ./Qwen3-0.6B
 ms cache clear --repo-type model --yes
 ms cache clear --repo-id my-org/old-model --repo-type model --yes
 ```
@@ -447,6 +449,7 @@ ms cache clear --repo-id my-org/old-model --repo-type model --yes
 | Subcommand | Key Options |
 |------------|-------------|
 | `scan` | `--cache-dir DIR` |
+| `verify REPO_ID` | `--repo-type`, `--revision`, `--cache-dir`, `--local-dir`, `--fail-on-missing-files`, `--fail-on-extra-files` |
 | `clear` | `--repo-type`, `--repo-id`, `--cache-dir`, `--yes` |
 
 </details>

--- a/src/modelscope_hub/__init__.py
+++ b/src/modelscope_hub/__init__.py
@@ -35,13 +35,15 @@ from .errors import (
     ValidationError,
 )
 from .types import (
-    CacheInfo,
     CachedRepoInfo,
+    CacheInfo,
+    CacheVerification,
     CommitInfo,
     FileInfo,
     PagedResult,
     RepoInfo,
     UserInfo,
+    VerificationMismatch,
 )
 from .version import __version__
 
@@ -62,12 +64,14 @@ __all__ = [
     "TqdmCallback",
     # Data classes
     "CacheInfo",
+    "CacheVerification",
     "CachedRepoInfo",
     "CommitInfo",
     "FileInfo",
     "PagedResult",
     "RepoInfo",
     "UserInfo",
+    "VerificationMismatch",
     # Errors (canonical names per error-code spec)
     "APIError",
     "AuthenticationError",

--- a/src/modelscope_hub/_cache_manager.py
+++ b/src/modelscope_hub/_cache_manager.py
@@ -221,8 +221,8 @@ def verify_cache(
     expected_by_path: dict[str, str | None],
     *,
     revision: str | None = None,
-    cache_dir: Path | None = None,
-    local_dir: Path | None = None,
+    cache_dir: str | Path | None = None,
+    local_dir: str | Path | None = None,
 ) -> CacheVerification:
     """Compare a cached snapshot or local directory with remote SHA-256 values."""
     root, resolved_revision = _resolve_verification_root(
@@ -268,16 +268,16 @@ def _resolve_verification_root(
     repo_type: str,
     *,
     revision: str | None,
-    cache_dir: Path | None,
-    local_dir: Path | None,
+    cache_dir: str | Path | None,
+    local_dir: str | Path | None,
 ) -> tuple[Path, str]:
     if local_dir is not None:
-        root = local_dir.expanduser().resolve()
+        root = Path(local_dir).expanduser().resolve()
         if not root.is_dir():
             raise CacheError(f"Local directory does not exist: {root}")
         return root, revision or "master"
 
-    cache_root = (cache_dir or get_default_config().cache_dir).expanduser().resolve()
+    cache_root = Path(cache_dir or get_default_config().cache_dir).expanduser().resolve()
     repo_root = cache_root / f"{repo_type}s" / repo_id.replace("/", "--")
     snapshots = repo_root / "snapshots"
     if not snapshots.is_dir():
@@ -293,6 +293,8 @@ def _resolve_verification_root(
     if default_snapshot.is_dir():
         return default_snapshot, "master"
     candidates = sorted(path for path in snapshots.iterdir() if path.is_dir())
+    if not candidates:
+        raise CacheError(f"No cached revisions found in: {snapshots}")
     if len(candidates) == 1:
         return candidates[0], candidates[0].name
     raise CacheError("Cached revision is ambiguous; pass --revision explicitly")

--- a/src/modelscope_hub/_cache_manager.py
+++ b/src/modelscope_hub/_cache_manager.py
@@ -232,7 +232,12 @@ def verify_cache(
         cache_dir=cache_dir,
         local_dir=local_dir,
     )
-    local_by_path = {path.relative_to(root).as_posix(): path for path in root.rglob("*") if path.is_file()}
+    local_by_path = {
+        relative.as_posix(): path
+        for path in root.rglob("*")
+        for relative in (path.relative_to(root),)
+        if path.is_file() and not any(part.startswith(".") for part in relative.parts)
+    }
     remote_paths = set(expected_by_path)
     local_paths = set(local_by_path)
     mismatches: list[VerificationMismatch] = []
@@ -290,9 +295,10 @@ def _resolve_verification_root(
             raise CacheError(f"Revision '{revision}' is not present in cache: {snapshot}")
         return snapshot, revision
 
-    default_snapshot = snapshots / "master"
-    if default_snapshot.is_dir():
-        return default_snapshot, "master"
+    for default_name in ("master", "main"):
+        default_snapshot = snapshots / default_name
+        if default_snapshot.is_dir():
+            return default_snapshot, default_name
     candidates = sorted(path for path in snapshots.iterdir() if path.is_dir())
     if not candidates:
         raise CacheError(f"No cached revisions found in: {snapshots}")

--- a/src/modelscope_hub/_cache_manager.py
+++ b/src/modelscope_hub/_cache_manager.py
@@ -12,7 +12,8 @@ from pathlib import Path
 from .config import get_default_config
 from .constants import RepoType
 from .errors import CacheError
-from .types import CacheInfo, CachedRepoInfo
+from .types import CachedRepoInfo, CacheInfo, CacheVerification, VerificationMismatch
+from .utils.file_utils import compute_hash
 from .utils.logger import get_logger
 
 logger = get_logger("cache")
@@ -76,15 +77,17 @@ def scan_cache(cache_dir: Path | None = None) -> CacheInfo:
             # Decode repo_id from directory name (owner--name → owner/name)
             repo_id = repo_dir.name.replace("--", "/")
 
-            repos.append(CachedRepoInfo(
-                repo_id=repo_id,
-                repo_type=repo_type,
-                revision=revision,
-                size_on_disk=size,
-                nb_files=nb_files,
-                last_accessed=last_accessed_ts if last_accessed_ts > 0 else None,
-                local_path=str(repo_dir),
-            ))
+            repos.append(
+                CachedRepoInfo(
+                    repo_id=repo_id,
+                    repo_type=repo_type,
+                    revision=revision,
+                    size_on_disk=size,
+                    nb_files=nb_files,
+                    last_accessed=last_accessed_ts if last_accessed_ts > 0 else None,
+                    local_path=str(repo_dir),
+                )
+            )
 
     # Scan flat layout (compat): {root}/{owner}/{name}/
     # and legacy layout: {root}/hub/{owner}/{name}/
@@ -110,15 +113,17 @@ def scan_cache(cache_dir: Path | None = None) -> CacheInfo:
                 nb_files = sum(1 for f in name_dir.rglob("*") if f.is_file())
                 repo_id = f"{owner_dir.name}/{name_dir.name}"
 
-                repos.append(CachedRepoInfo(
-                    repo_id=repo_id,
-                    repo_type=RepoType.MODEL,  # assume model for flat layout
-                    revision=None,
-                    size_on_disk=size,
-                    nb_files=nb_files,
-                    last_accessed=None,
-                    local_path=str(name_dir),
-                ))
+                repos.append(
+                    CachedRepoInfo(
+                        repo_id=repo_id,
+                        repo_type=RepoType.MODEL,  # assume model for flat layout
+                        revision=None,
+                        size_on_disk=size,
+                        nb_files=nb_files,
+                        last_accessed=None,
+                        local_path=str(name_dir),
+                    )
+                )
 
     return CacheInfo(
         repos=repos,
@@ -210,9 +215,89 @@ def clear_cache(
     return freed
 
 
+def verify_cache(
+    repo_id: str,
+    repo_type: str,
+    expected_by_path: dict[str, str | None],
+    *,
+    revision: str | None = None,
+    cache_dir: Path | None = None,
+    local_dir: Path | None = None,
+) -> CacheVerification:
+    """Compare a cached snapshot or local directory with remote SHA-256 values."""
+    root, resolved_revision = _resolve_verification_root(
+        repo_id,
+        repo_type,
+        revision=revision,
+        cache_dir=cache_dir,
+        local_dir=local_dir,
+    )
+    local_by_path = {path.relative_to(root).as_posix(): path for path in root.rglob("*") if path.is_file()}
+    remote_paths = set(expected_by_path)
+    local_paths = set(local_by_path)
+    mismatches: list[VerificationMismatch] = []
+    unverified: list[str] = []
+    checked = 0
+
+    for rel_path in sorted(remote_paths & local_paths):
+        expected = expected_by_path[rel_path]
+        if not expected:
+            unverified.append(rel_path)
+            continue
+        checked += 1
+        actual = compute_hash(local_by_path[rel_path], "sha256")
+        if actual.lower() != expected.lower():
+            mismatches.append(VerificationMismatch(rel_path, expected.lower(), actual.lower()))
+
+    return CacheVerification(
+        revision=resolved_revision,
+        verified_path=str(root),
+        checked_count=checked,
+        mismatches=mismatches,
+        missing_paths=sorted(remote_paths - local_paths),
+        extra_paths=sorted(local_paths - remote_paths),
+        unverified_paths=unverified,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+def _resolve_verification_root(
+    repo_id: str,
+    repo_type: str,
+    *,
+    revision: str | None,
+    cache_dir: Path | None,
+    local_dir: Path | None,
+) -> tuple[Path, str]:
+    if local_dir is not None:
+        root = local_dir.expanduser().resolve()
+        if not root.is_dir():
+            raise CacheError(f"Local directory does not exist: {root}")
+        return root, revision or "master"
+
+    cache_root = (cache_dir or get_default_config().cache_dir).expanduser().resolve()
+    repo_root = cache_root / f"{repo_type}s" / repo_id.replace("/", "--")
+    snapshots = repo_root / "snapshots"
+    if not snapshots.is_dir():
+        raise CacheError(f"Repository is not present in cache: {repo_root}")
+
+    if revision:
+        snapshot = snapshots / revision
+        if not snapshot.is_dir():
+            raise CacheError(f"Revision '{revision}' is not present in cache: {snapshot}")
+        return snapshot, revision
+
+    default_snapshot = snapshots / "master"
+    if default_snapshot.is_dir():
+        return default_snapshot, "master"
+    candidates = sorted(path for path in snapshots.iterdir() if path.is_dir())
+    if len(candidates) == 1:
+        return candidates[0], candidates[0].name
+    raise CacheError("Cached revision is ambiguous; pass --revision explicitly")
+
+
 def _resolve_cache_targets(root: Path, repo_id: str, repo_type: str) -> list[Path]:
     """Resolve all possible cache locations for a repo across layout formats.
 
@@ -225,9 +310,9 @@ def _resolve_cache_targets(root: Path, repo_id: str, repo_type: str) -> list[Pat
     segment = f"{repo_type}s" if not repo_type.endswith("s") else repo_type
 
     candidates = [
-        root / segment / safe_id,    # standard: {cache}/models/owner--name/
-        root / repo_id,              # flat (compat): {cache}/owner/name/
-        root / "hub" / repo_id,      # legacy: {cache}/hub/owner/name/
+        root / segment / safe_id,  # standard: {cache}/models/owner--name/
+        root / repo_id,  # flat (compat): {cache}/owner/name/
+        root / "hub" / repo_id,  # legacy: {cache}/hub/owner/name/
     ]
     return [p for p in candidates if p.is_dir()]
 

--- a/src/modelscope_hub/_cache_manager.py
+++ b/src/modelscope_hub/_cache_manager.py
@@ -278,7 +278,8 @@ def _resolve_verification_root(
         return root, revision or "master"
 
     cache_root = Path(cache_dir or get_default_config().cache_dir).expanduser().resolve()
-    repo_root = cache_root / f"{repo_type}s" / repo_id.replace("/", "--")
+    segment = f"{repo_type}s" if not repo_type.endswith("s") else repo_type
+    repo_root = cache_root / segment / repo_id.replace("/", "--")
     snapshots = repo_root / "snapshots"
     if not snapshots.is_dir():
         raise CacheError(f"Repository is not present in cache: {repo_root}")

--- a/src/modelscope_hub/api.py
+++ b/src/modelscope_hub/api.py
@@ -31,6 +31,7 @@ from requests.cookies import RequestsCookieJar
 
 from ._cache_manager import clear_cache as _clear_cache
 from ._cache_manager import scan_cache as _scan_cache
+from ._cache_manager import verify_cache as _verify_cache
 from ._download import DownloadManager
 from ._legacy_api import LegacyClient
 from ._openapi import OpenAPIClient
@@ -45,7 +46,7 @@ from .errors import (
     NotExistError,
     NotSupportedError,
 )
-from .types import CacheInfo, FileInfo, PagedResult, RepoInfo, UserInfo
+from .types import CacheInfo, CacheVerification, FileInfo, PagedResult, RepoInfo, UserInfo
 from .utils.logger import get_logger
 
 __all__ = ["HubApi"]
@@ -57,9 +58,7 @@ RepoTypeLike = "str | RepoType"
 
 # Routing tables — declarative dispatch keeps :class:`HubApi` free of long
 # if/elif chains and makes adding new repo types a one-line change.
-_CREATABLE_TYPES: frozenset[RepoType] = frozenset(
-    {RepoType.MODEL, RepoType.DATASET, RepoType.STUDIO, RepoType.SKILL}
-)
+_CREATABLE_TYPES: frozenset[RepoType] = frozenset({RepoType.MODEL, RepoType.DATASET, RepoType.STUDIO, RepoType.SKILL})
 _OPENAPI_CREATE_TYPES: frozenset[RepoType] = frozenset({RepoType.STUDIO, RepoType.SKILL})
 _OPENAPI_DETAIL_TYPES: frozenset[RepoType] = frozenset(
     {RepoType.MODEL, RepoType.DATASET, RepoType.STUDIO, RepoType.SKILL}
@@ -92,9 +91,7 @@ _STUDIO_FIELD_RENAMES: dict[str, str] = {
 
 # Reserved fields that are controlled by create_repo method parameters.
 # These MUST NOT be overridden via extra kwargs to avoid silent conflicts.
-_RESERVED_EXTRA_FIELDS: frozenset[str] = frozenset(
-    {"Path", "Owner", "Name"}
-)
+_RESERVED_EXTRA_FIELDS: frozenset[str] = frozenset({"Path", "Owner", "Name"})
 
 
 class HubApi:
@@ -148,6 +145,7 @@ class HubApi:
         base = config or get_default_config()
         if config is None and (endpoint is not None or token is not None):
             from dataclasses import replace
+
             was_overridden = base._endpoint_overridden
             base = replace(base)
             # replace() re-runs __post_init__ which sees the inherited
@@ -221,9 +219,7 @@ class HubApi:
     def _parse_repo_id(repo_id: str) -> tuple[str, str]:
         """Split a canonical ``owner/name`` identifier into its two halves."""
         if not repo_id or "/" not in repo_id:
-            raise InvalidParameter(
-                f"repo_id {repo_id!r} should be in format of 'owner/name'."
-            )
+            raise InvalidParameter(f"repo_id {repo_id!r} should be in format of 'owner/name'.")
         owner, _, name = repo_id.partition("/")
         if not owner or not name:
             raise InvalidParameter(
@@ -247,9 +243,7 @@ class HubApi:
             return RepoType(str(repo_type).lower())
         except ValueError as exc:
             allowed = ", ".join(t.value for t in RepoType)
-            raise InvalidParameter(
-                f"Unknown repo_type {repo_type!r}. Expected one of: {allowed}."
-            ) from exc
+            raise InvalidParameter(f"Unknown repo_type {repo_type!r}. Expected one of: {allowed}.") from exc
 
     @staticmethod
     def _normalize_visibility(visibility: int | str | Visibility | None) -> int | None:
@@ -263,14 +257,34 @@ class HubApi:
         return int(Visibility.from_label(str(visibility)))
 
     _PAGED_ITEM_KEYS = (
-        "items", "list", "data", "results",
-        "models", "datasets", "skills", "servers", "mcp_server_list",
-        "Models", "Datasets", "Skills", "Servers",
+        "items",
+        "list",
+        "data",
+        "results",
+        "models",
+        "datasets",
+        "skills",
+        "servers",
+        "mcp_server_list",
+        "Models",
+        "Datasets",
+        "Skills",
+        "Servers",
     )
-    _PAGED_META_KEYS = frozenset({
-        "total_count", "total", "page_number", "page", "page_size", "size",
-        "TotalCount", "Total", "PageNumber", "PageSize",
-    })
+    _PAGED_META_KEYS = frozenset(
+        {
+            "total_count",
+            "total",
+            "page_number",
+            "page",
+            "page_size",
+            "size",
+            "TotalCount",
+            "Total",
+            "PageNumber",
+            "PageSize",
+        }
+    )
 
     @staticmethod
     def _extract_paged(payload: Any) -> tuple[list[Any], int, int, int]:
@@ -626,8 +640,7 @@ class HubApi:
         if rt not in _CREATABLE_TYPES:
             supported = ", ".join(sorted(t.value for t in _CREATABLE_TYPES))
             raise NotSupportedError(
-                f"create_repo does not support repo_type={rt.value!r}. "
-                f"Supported types: {supported}."
+                f"create_repo does not support repo_type={rt.value!r}. Supported types: {supported}."
             )
         owner, name = self._parse_repo_id(repo_id)
         vis = self._normalize_visibility(visibility)
@@ -662,14 +675,8 @@ class HubApi:
                 if old_key in extra:
                     extra[new_key] = extra.pop(old_key)
             payload.update(extra)
-            data = (
-                self.openapi.create_studio(payload)
-                if rt is RepoType.STUDIO
-                else self.openapi.create_skill(payload)
-            )
-            return self._repo_info_from_payload(
-                data, rt, owner_hint=owner, name_hint=name
-            )
+            data = self.openapi.create_studio(payload) if rt is RepoType.STUDIO else self.openapi.create_skill(payload)
+            return self._repo_info_from_payload(data, rt, owner_hint=owner, name_hint=name)
 
         if rt is RepoType.DATASET:
             body: dict[str, Any] = {
@@ -707,24 +714,17 @@ class HubApi:
         filtered: dict[str, Any] = {}
         for k, v in extra.items():
             if k in _RESERVED_EXTRA_FIELDS:
-                logger.warning(
-                    "Reserved field %r in extra ignored (controlled by method params)", k
-                )
+                logger.warning("Reserved field %r in extra ignored (controlled by method params)", k)
                 continue
             filtered[k] = v
         if "ProtectedMode" in filtered:
             pm = filtered["ProtectedMode"]
             if not isinstance(pm, int) or isinstance(pm, bool) or pm not in (1, 2):
-                raise ValueError(
-                    "ProtectedMode must be int 1 (gated) or 2 (off); "
-                    "use gated_mode=True/False instead"
-                )
+                raise ValueError("ProtectedMode must be int 1 (gated) or 2 (off); use gated_mode=True/False instead")
         body.update(filtered)
 
         data = self.legacy.create_repo(repo_type=str(rt), body=body)
-        return self._repo_info_from_payload(
-            data, rt, owner_hint=owner, name_hint=name
-        )
+        return self._repo_info_from_payload(data, rt, owner_hint=owner, name_hint=name)
 
     def get_repo(
         self,
@@ -791,9 +791,7 @@ class HubApi:
         else:  # pragma: no cover - defensive
             raise NotSupportedError(f"get_repo not supported for {rt}")
 
-        return self._repo_info_from_payload(
-            data, rt, owner_hint=owner, name_hint=name
-        )
+        return self._repo_info_from_payload(data, rt, owner_hint=owner, name_hint=name)
 
     def list_repos(
         self,
@@ -855,14 +853,20 @@ class HubApi:
 
         if rt is RepoType.MODEL:
             payload = self.openapi.list_models(
-                search=search, owner=owner, sort=sort,
-                page_number=page_number, page_size=page_size,
+                search=search,
+                owner=owner,
+                sort=sort,
+                page_number=page_number,
+                page_size=page_size,
                 filters=clean_filters or None,
             )
         elif rt is RepoType.DATASET:
             payload = self.openapi.list_datasets(
-                search=search, owner=owner, sort=sort,
-                page_number=page_number, page_size=page_size,
+                search=search,
+                owner=owner,
+                sort=sort,
+                page_number=page_number,
+                page_size=page_size,
                 filters=clean_filters or None,
             )
         elif rt is RepoType.SKILL:
@@ -870,19 +874,19 @@ class HubApi:
                 clean_filters.setdefault("owner", owner)
             payload = self.openapi.list_skills(
                 search=search,
-                page_number=page_number, page_size=page_size,
+                page_number=page_number,
+                page_size=page_size,
                 filters=clean_filters or None,
             )
         elif rt is RepoType.MCP:
             payload = self.openapi.list_mcp_servers(
                 search=search,
-                page_number=page_number, page_size=page_size,
+                page_number=page_number,
+                page_size=page_size,
                 filter=clean_filters or None,
             )
         elif rt is RepoType.STUDIO:
-            raise NotSupportedError(
-                "Listing studios is not supported by the OpenAPI surface yet."
-            )
+            raise NotSupportedError("Listing studios is not supported by the OpenAPI surface yet.")
         else:  # pragma: no cover - defensive
             raise NotSupportedError(f"list_repos not supported for {rt}")
 
@@ -920,6 +924,7 @@ class HubApi:
             Repository type (``"model"``, ``"dataset"``, etc.).
         """
         import warnings
+
         warnings.warn(
             "This function is deprecated due to security reasons, "
             "and will be recovered in future versions with proper token authentication. "
@@ -1010,9 +1015,7 @@ class HubApi:
             )
             return fallback
 
-        raise NotExistError(
-            f"Repo {repo_id} not found on either {primary} or {fallback}"
-        )
+        raise NotExistError(f"Repo {repo_id} not found on either {primary} or {fallback}")
 
     # ==================================================================
     # Files
@@ -1401,6 +1404,7 @@ class HubApi:
                 "path": item.get("Path") or item.get("path") or item.get("Name") or "",
                 "size": int(item.get("Size") or item.get("size") or 0),
                 "blob_id": item.get("BlobId") or item.get("blob_id") or item.get("Sha256"),
+                "sha256": item.get("Sha256") or item.get("sha256"),
                 "type": item.get("Type") or item.get("type") or "blob",
                 "last_modified": item.get("CommittedDate") or item.get("last_modified"),
                 "lfs": item.get("Lfs") or item.get("lfs"),
@@ -1481,9 +1485,7 @@ class HubApi:
     # ==================================================================
     # Versioning
     # ==================================================================
-    def list_repo_revisions(
-        self, repo_id: str, repo_type: RepoTypeLike
-    ) -> list[dict]:
+    def list_repo_revisions(self, repo_id: str, repo_type: RepoTypeLike) -> list[dict]:
         """Return branches and tags of a repository (legacy).
 
         Examples
@@ -1566,9 +1568,7 @@ class HubApi:
             return self.openapi.deploy_studio(owner, name, payload)
         if rt is RepoType.MCP:
             return self.openapi.deploy_mcp_server(repo_id, payload)
-        raise NotSupportedError(
-            f"deploy_repo is not supported for repo_type={rt.value!r}."
-        )
+        raise NotSupportedError(f"deploy_repo is not supported for repo_type={rt.value!r}.")
 
     def stop_repo(
         self,
@@ -1587,9 +1587,7 @@ class HubApi:
             return self.openapi.stop_studio(owner, name)
         if rt is RepoType.MCP:
             return self.openapi.undeploy_mcp_server(repo_id)
-        raise NotSupportedError(
-            f"stop_repo is not supported for repo_type={rt.value!r}."
-        )
+        raise NotSupportedError(f"stop_repo is not supported for repo_type={rt.value!r}.")
 
     def get_repo_logs(
         self,
@@ -1643,14 +1641,17 @@ class HubApi:
         """
         rt = self._normalize_repo_type(repo_type)
         if rt is not RepoType.STUDIO:
-            raise NotSupportedError(
-                f"get_repo_logs is currently only supported for studio (got {rt.value!r})."
-            )
+            raise NotSupportedError(f"get_repo_logs is currently only supported for studio (got {rt.value!r}).")
         owner, name = self._parse_repo_id(repo_id)
         return self.openapi.get_studio_logs(
-            owner, name, log_type,
-            page_num=page_num, page_size=page_size, keyword=keyword,
-            start_timestamp=start_timestamp, end_timestamp=end_timestamp,
+            owner,
+            name,
+            log_type,
+            page_num=page_num,
+            page_size=page_size,
+            keyword=keyword,
+            start_timestamp=start_timestamp,
+            end_timestamp=end_timestamp,
         )
 
     def update_repo_settings(
@@ -1698,16 +1699,12 @@ class HubApi:
             return self.openapi.update_studio_settings(owner, name, settings)
         if rt is RepoType.SKILL:
             return self.openapi.update_skill_settings(owner, name, settings)
-        raise NotSupportedError(
-            f"update_repo_settings is not supported for repo_type={rt.value!r}."
-        )
+        raise NotSupportedError(f"update_repo_settings is not supported for repo_type={rt.value!r}.")
 
     # ==================================================================
     # Secrets
     # ==================================================================
-    def list_secrets(
-        self, repo_id: str, repo_type: RepoTypeLike = RepoType.STUDIO
-    ) -> list[dict]:
+    def list_secrets(self, repo_id: str, repo_type: RepoTypeLike = RepoType.STUDIO) -> list[dict]:
         """List secrets attached to a Studio.
 
         Examples
@@ -1717,9 +1714,7 @@ class HubApi:
         """
         rt = self._normalize_repo_type(repo_type)
         if rt is not RepoType.STUDIO:
-            raise NotSupportedError(
-                f"Secret management is only supported for studio (got {rt.value!r})."
-            )
+            raise NotSupportedError(f"Secret management is only supported for studio (got {rt.value!r}).")
         owner, name = self._parse_repo_id(repo_id)
         data = self.openapi.list_studio_secrets(owner, name)
         if isinstance(data, list):
@@ -1856,13 +1851,9 @@ class HubApi:
         >>> info["operational_url"]
         'https://...'
         """
-        return self.openapi.get_mcp_server(
-            server_id, get_operational_url=get_operational_url
-        )
+        return self.openapi.get_mcp_server(server_id, get_operational_url=get_operational_url)
 
-    def deploy_mcp_server(
-        self, server_id: str, *, payload: Mapping[str, Any] | None = None
-    ) -> dict:
+    def deploy_mcp_server(self, server_id: str, *, payload: Mapping[str, Any] | None = None) -> dict:
         """Deploy or redeploy an MCP server.
 
         Examples
@@ -1883,6 +1874,30 @@ class HubApi:
     # ==================================================================
     # Cache
     # ==================================================================
+    def verify_cache(
+        self,
+        repo_id: str,
+        repo_type: RepoTypeLike = "model",
+        *,
+        revision: str | None = None,
+        cache_dir: str | Path | None = None,
+        local_dir: str | Path | None = None,
+    ) -> CacheVerification:
+        """Verify local repository files against SHA-256 checksums from the Hub."""
+        if cache_dir is not None and local_dir is not None:
+            raise InvalidParameter("cache_dir and local_dir are mutually exclusive")
+        rt = self._normalize_repo_type(repo_type)
+        files = self.list_repo_files(repo_id, rt, revision=revision, recursive=True)
+        expected = {file.path: file.sha256 for file in files if not file.is_dir and file.path}
+        return _verify_cache(
+            repo_id,
+            str(rt),
+            expected,
+            revision=revision,
+            cache_dir=Path(cache_dir) if cache_dir else None,
+            local_dir=Path(local_dir) if local_dir else None,
+        )
+
     def scan_cache(self, cache_dir: str | Path | None = None) -> CacheInfo:
         """Inspect the local cache directory.
 

--- a/src/modelscope_hub/api.py
+++ b/src/modelscope_hub/api.py
@@ -30,6 +30,7 @@ from urllib.parse import urlparse
 from requests.cookies import RequestsCookieJar
 
 from ._cache_manager import clear_cache as _clear_cache
+from ._cache_manager import _resolve_verification_root
 from ._cache_manager import scan_cache as _scan_cache
 from ._cache_manager import verify_cache as _verify_cache
 from ._download import DownloadManager
@@ -1887,13 +1888,20 @@ class HubApi:
         if cache_dir is not None and local_dir is not None:
             raise InvalidParameter("cache_dir and local_dir are mutually exclusive")
         rt = self._normalize_repo_type(repo_type)
-        files = self.list_repo_files(repo_id, rt, revision=revision, recursive=True)
+        _, resolved_revision = _resolve_verification_root(
+            repo_id,
+            str(rt),
+            revision=revision,
+            cache_dir=cache_dir,
+            local_dir=local_dir,
+        )
+        files = self.list_repo_files(repo_id, rt, revision=resolved_revision, recursive=True)
         expected = {file.path: file.sha256 for file in files if not file.is_dir and file.path}
         return _verify_cache(
             repo_id,
             str(rt),
             expected,
-            revision=revision,
+            revision=resolved_revision,
             cache_dir=Path(cache_dir) if cache_dir else None,
             local_dir=Path(local_dir) if local_dir else None,
         )

--- a/src/modelscope_hub/cli/cache.py
+++ b/src/modelscope_hub/cli/cache.py
@@ -7,7 +7,7 @@ from argparse import Action
 
 from ..constants import RepoType
 from ..utils.format import format_size
-from .base import CLICommand, info, make_api, render_table, success
+from .base import CLICommand, error, info, make_api, render_table, success, warn
 
 
 class CacheCommand(CLICommand):
@@ -21,6 +21,7 @@ class CacheCommand(CLICommand):
 
         _CacheScan.register(sub)
         _CacheClear.register(sub)
+        _CacheVerify.register(sub)
 
         parser.set_defaults(_command=CacheCommand)
 
@@ -62,10 +63,12 @@ class _CacheScan(CLICommand):
             for r in report.repos
         ]
         info("")
-        info(render_table(
-            rows,
-            headers=["repo_id", "repo_type", "revision", "files", "size", "path"],
-        ))
+        info(
+            render_table(
+                rows,
+                headers=["repo_id", "repo_type", "revision", "files", "size", "path"],
+            )
+        )
 
 
 class _CacheClear(CLICommand):
@@ -106,3 +109,57 @@ class _CacheClear(CLICommand):
             repo_id=self.args.repo_id,
         )
         success(f"Freed {_human_size(freed)} from cache.")
+
+
+class _CacheVerify(CLICommand):
+    @staticmethod
+    def register(subparsers: Action) -> None:
+        p = subparsers.add_parser("verify", help="Verify local files against Hub SHA-256 checksums.")
+        p.add_argument("repo_id", help="Repository id in owner/name form.")
+        p.add_argument(
+            "--repo-type",
+            choices=[t.value for t in RepoType],
+            default="model",
+        )
+        p.add_argument("--revision", default=None)
+        location = p.add_mutually_exclusive_group()
+        location.add_argument("--cache-dir", default=None)
+        location.add_argument("--local-dir", default=None)
+        p.add_argument("--fail-on-missing-files", action="store_true")
+        p.add_argument("--fail-on-extra-files", action="store_true")
+        p.set_defaults(_command=CacheCommand, _cache_leaf=_CacheVerify)
+
+    def execute(self) -> None:
+        api = make_api(self.args)
+        result = api.verify_cache(
+            self.args.repo_id,
+            self.args.repo_type,
+            revision=self.args.revision,
+            cache_dir=self.args.cache_dir,
+            local_dir=self.args.local_dir,
+        )
+        failed = bool(result.mismatches)
+        for mismatch in result.mismatches:
+            error(f"{mismatch.path}: expected {mismatch.expected} ({mismatch.algorithm}), got {mismatch.actual}")
+        if result.missing_paths:
+            message = f"{len(result.missing_paths)} remote file(s) are missing locally"
+            if self.args.fail_on_missing_files:
+                error(message + ": " + ", ".join(result.missing_paths))
+                failed = True
+            else:
+                warn(message)
+        if result.extra_paths:
+            message = f"{len(result.extra_paths)} local file(s) are absent from the remote revision"
+            if self.args.fail_on_extra_files:
+                error(message + ": " + ", ".join(result.extra_paths))
+                failed = True
+            else:
+                warn(message)
+        if result.unverified_paths:
+            warn(f"{len(result.unverified_paths)} file(s) have no SHA-256 metadata and were skipped")
+        if failed:
+            raise SystemExit(1)
+        success(
+            f"Verified {result.checked_count} file(s) for {self.args.repo_type} "
+            f"'{self.args.repo_id}' at {result.verified_path}."
+        )

--- a/src/modelscope_hub/cli/cache.py
+++ b/src/modelscope_hub/cli/cache.py
@@ -111,6 +111,12 @@ class _CacheClear(CLICommand):
         success(f"Freed {_human_size(freed)} from cache.")
 
 
+def _format_paths(paths: list[str], limit: int = 10) -> str:
+    """Format a bounded path list for verification diagnostics."""
+    details = ", ".join(paths[:limit])
+    return details + ("..." if len(paths) > limit else "")
+
+
 class _CacheVerify(CLICommand):
     @staticmethod
     def register(subparsers: Action) -> None:
@@ -143,18 +149,20 @@ class _CacheVerify(CLICommand):
             error(f"{mismatch.path}: expected {mismatch.expected} ({mismatch.algorithm}), got {mismatch.actual}")
         if result.missing_paths:
             message = f"{len(result.missing_paths)} remote file(s) are missing locally"
+            details = _format_paths(result.missing_paths)
             if self.args.fail_on_missing_files:
-                error(message + ": " + ", ".join(result.missing_paths))
+                error(f"{message}: {details}")
                 failed = True
             else:
-                warn(message)
+                warn(f"{message}: {details}")
         if result.extra_paths:
             message = f"{len(result.extra_paths)} local file(s) are absent from the remote revision"
+            details = _format_paths(result.extra_paths)
             if self.args.fail_on_extra_files:
-                error(message + ": " + ", ".join(result.extra_paths))
+                error(f"{message}: {details}")
                 failed = True
             else:
-                warn(message)
+                warn(f"{message}: {details}")
         if result.unverified_paths:
             warn(f"{len(result.unverified_paths)} file(s) have no SHA-256 metadata and were skipped")
         if failed:

--- a/src/modelscope_hub/types.py
+++ b/src/modelscope_hub/types.py
@@ -139,6 +139,7 @@ class FileInfo(_FromDictMixin):
     path: str = ""
     size: int = 0
     blob_id: str | None = None
+    sha256: str | None = None
     type: str = "blob"  # "blob" | "tree"
     last_modified: datetime | str | int | None = None
     lfs: dict[str, Any] | None = None
@@ -189,10 +190,7 @@ class PagedResult(Generic[T]):
         Uses collection_key for the items array name (e.g. 'datasets', 'models').
         """
         return {
-            self.collection_key: [
-                item.to_dict() if hasattr(item, "to_dict") else item
-                for item in self.items
-            ],
+            self.collection_key: [item.to_dict() if hasattr(item, "to_dict") else item for item in self.items],
             "total_count": self.total_count,
             "page_number": self.page_number,
             "page_size": self.page_size,
@@ -232,6 +230,31 @@ class CacheInfo:
     repos: list[CachedRepoInfo] = field(default_factory=list)
     total_size: int = 0
     cache_dir: str | None = None
+
+    @property
+    def total_repos(self) -> int:
+        return len(self.repos)
+
+
+@dataclass(slots=True)
+class VerificationMismatch:
+    path: str
+    expected: str
+    actual: str
+    algorithm: str = "sha256"
+
+
+@dataclass(slots=True)
+class CacheVerification:
+    """Result of comparing local repository files with Hub checksums."""
+
+    revision: str
+    verified_path: str
+    checked_count: int = 0
+    mismatches: list[VerificationMismatch] = field(default_factory=list)
+    missing_paths: list[str] = field(default_factory=list)
+    extra_paths: list[str] = field(default_factory=list)
+    unverified_paths: list[str] = field(default_factory=list)
 
     @property
     def total_repos(self) -> int:
@@ -311,6 +334,7 @@ class DeployMcpServerPayload(TypedDict, total=False):
 
 
 __all__ = [
+    "CacheVerification",
     "CacheInfo",
     "CachedRepoInfo",
     "CommitInfo",
@@ -323,4 +347,5 @@ __all__ = [
     "UpdateSkillSettingsPayload",
     "UpdateStudioSettingsPayload",
     "UserInfo",
+    "VerificationMismatch",
 ]

--- a/src/modelscope_hub/types.py
+++ b/src/modelscope_hub/types.py
@@ -139,10 +139,10 @@ class FileInfo(_FromDictMixin):
     path: str = ""
     size: int = 0
     blob_id: str | None = None
-    sha256: str | None = None
     type: str = "blob"  # "blob" | "tree"
     last_modified: datetime | str | int | None = None
     lfs: dict[str, Any] | None = None
+    sha256: str | None = None
 
     def __post_init__(self) -> None:
         self.last_modified = _coerce_datetime(self.last_modified) or self.last_modified

--- a/src/modelscope_hub/types.py
+++ b/src/modelscope_hub/types.py
@@ -256,10 +256,6 @@ class CacheVerification:
     extra_paths: list[str] = field(default_factory=list)
     unverified_paths: list[str] = field(default_factory=list)
 
-    @property
-    def total_repos(self) -> int:
-        return len(self.repos)
-
 
 # ---------------------------------------------------------------------------
 # TypedDict payloads (for OpenAPI method signatures)

--- a/tests/cli/test_cache.py
+++ b/tests/cli/test_cache.py
@@ -6,6 +6,7 @@ Includes:
 - Legacy alias tests: scan-cache, clear-cache
 - Remote tests: real API cache lifecycle (existing)
 """
+
 from __future__ import annotations
 
 import base64
@@ -14,8 +15,8 @@ from unittest.mock import patch
 
 import pytest
 
-from modelscope_hub.cli.cache import CacheCommand, _CacheClear, _CacheScan
-from modelscope_hub.types import CacheInfo
+from modelscope_hub.cli.cache import _CacheClear, _CacheScan, _CacheVerify
+from modelscope_hub.types import CacheInfo, CacheVerification, VerificationMismatch
 
 from .conftest import run_cli
 
@@ -47,30 +48,54 @@ class TestCacheClearParser:
         assert args.yes is True
 
     def test_repo_type(self, parser):
-        args = parser.parse_args([
-            "cache", "clear", "--repo-type", "model", "--yes",
-        ])
+        args = parser.parse_args(
+            [
+                "cache",
+                "clear",
+                "--repo-type",
+                "model",
+                "--yes",
+            ]
+        )
         assert args.repo_type == "model"
 
     @pytest.mark.parametrize("repo_type", ["model", "dataset", "studio", "skill", "mcp"])
     def test_all_repo_types(self, parser, repo_type):
-        args = parser.parse_args([
-            "cache", "clear", "--repo-type", repo_type, "--yes",
-        ])
+        args = parser.parse_args(
+            [
+                "cache",
+                "clear",
+                "--repo-type",
+                repo_type,
+                "--yes",
+            ]
+        )
         assert args.repo_type == repo_type
 
     def test_repo_id(self, parser):
-        args = parser.parse_args([
-            "cache", "clear",
-            "--repo-type", "model", "--repo-id", "owner/model1",
-            "--yes",
-        ])
+        args = parser.parse_args(
+            [
+                "cache",
+                "clear",
+                "--repo-type",
+                "model",
+                "--repo-id",
+                "owner/model1",
+                "--yes",
+            ]
+        )
         assert args.repo_id == "owner/model1"
 
     def test_cache_dir(self, parser):
-        args = parser.parse_args([
-            "cache", "clear", "--cache-dir", "/data/cache", "--yes",
-        ])
+        args = parser.parse_args(
+            [
+                "cache",
+                "clear",
+                "--cache-dir",
+                "/data/cache",
+                "--yes",
+            ]
+        )
         assert args.cache_dir == "/data/cache"
 
     def test_yes_short_flag(self, parser):
@@ -80,6 +105,27 @@ class TestCacheClearParser:
     def test_yes_default_false(self, parser):
         args = parser.parse_args(["cache", "clear"])
         assert args.yes is False
+
+
+class TestCacheVerifyParser:
+    def test_defaults(self, parser):
+        args = parser.parse_args(["cache", "verify", "owner/repo"])
+        assert args.repo_id == "owner/repo"
+        assert args.repo_type == "model"
+
+    def test_locations_are_mutually_exclusive(self, parser):
+        with pytest.raises(SystemExit):
+            parser.parse_args(
+                [
+                    "cache",
+                    "verify",
+                    "owner/repo",
+                    "--cache-dir",
+                    "/cache",
+                    "--local-dir",
+                    "/repo",
+                ]
+            )
 
 
 class TestCacheLegacyAliases:
@@ -106,9 +152,15 @@ class TestCacheLegacyAliases:
         assert args.dataset == "owner/data"
 
     def test_clear_cache_with_cache_dir(self, parser):
-        args = parser.parse_args([
-            "clear-cache", "--model", "owner/repo", "--cache-dir", "/tmp",
-        ])
+        args = parser.parse_args(
+            [
+                "clear-cache",
+                "--model",
+                "owner/repo",
+                "--cache-dir",
+                "/tmp",
+            ]
+        )
         assert args.cache_dir == "/tmp"
 
     def test_clear_cache_yes_flag(self, parser):
@@ -144,7 +196,9 @@ class TestCacheScanExecute:
 
     def test_scan_empty(self, parser, mock_api, capsys):
         mock_api.scan_cache.return_value = CacheInfo(
-            cache_dir="/tmp/cache", total_size=0, repos=[],
+            cache_dir="/tmp/cache",
+            total_size=0,
+            repos=[],
         )
         args = parser.parse_args(["cache", "scan"])
         with patch("modelscope_hub.cli.cache.make_api", return_value=mock_api):
@@ -158,9 +212,15 @@ class TestCacheClearExecute:
     """_CacheClear.execute() logic."""
 
     def test_clear_with_yes(self, parser, mock_api, capsys):
-        args = parser.parse_args([
-            "cache", "clear", "--repo-type", "model", "--yes",
-        ])
+        args = parser.parse_args(
+            [
+                "cache",
+                "clear",
+                "--repo-type",
+                "model",
+                "--yes",
+            ]
+        )
         with patch("modelscope_hub.cli.cache.make_api", return_value=mock_api):
             _CacheClear(args).execute()
         mock_api.clear_cache.assert_called_once()
@@ -195,11 +255,17 @@ class TestCacheClearExecute:
             assert exc_info.value.code == 2
 
     def test_clear_specific_repo(self, parser, mock_api, capsys):
-        args = parser.parse_args([
-            "cache", "clear",
-            "--repo-type", "model", "--repo-id", "owner/repo",
-            "--yes",
-        ])
+        args = parser.parse_args(
+            [
+                "cache",
+                "clear",
+                "--repo-type",
+                "model",
+                "--repo-id",
+                "owner/repo",
+                "--yes",
+            ]
+        )
         with patch("modelscope_hub.cli.cache.make_api", return_value=mock_api):
             _CacheClear(args).execute()
         kw = mock_api.clear_cache.call_args.kwargs
@@ -207,12 +273,45 @@ class TestCacheClearExecute:
         assert kw["repo_id"] == "owner/repo"
 
     def test_clear_cache_dir_forwarded(self, parser, mock_api, capsys):
-        args = parser.parse_args([
-            "cache", "clear", "--cache-dir", "/data", "--yes",
-        ])
+        args = parser.parse_args(
+            [
+                "cache",
+                "clear",
+                "--cache-dir",
+                "/data",
+                "--yes",
+            ]
+        )
         with patch("modelscope_hub.cli.cache.make_api", return_value=mock_api):
             _CacheClear(args).execute()
         assert mock_api.clear_cache.call_args.kwargs["cache_dir"] == "/data"
+
+
+@pytest.mark.mock_only
+class TestCacheVerifyExecute:
+    def test_success(self, parser, mock_api, capsys):
+        mock_api.verify_cache.return_value = CacheVerification(
+            revision="master",
+            verified_path="/cache/snapshot",
+            checked_count=2,
+        )
+        args = parser.parse_args(["cache", "verify", "owner/repo"])
+        with patch("modelscope_hub.cli.cache.make_api", return_value=mock_api):
+            _CacheVerify(args).execute()
+        assert "Verified 2 file(s)" in capsys.readouterr().out
+
+    def test_mismatch_exits_nonzero(self, parser, mock_api, capsys):
+        mock_api.verify_cache.return_value = CacheVerification(
+            revision="master",
+            verified_path="/cache/snapshot",
+            mismatches=[VerificationMismatch("weights.bin", "expected", "actual")],
+        )
+        args = parser.parse_args(["cache", "verify", "owner/repo"])
+        with patch("modelscope_hub.cli.cache.make_api", return_value=mock_api):
+            with pytest.raises(SystemExit) as exc_info:
+                _CacheVerify(args).execute()
+        assert exc_info.value.code == 1
+        assert "weights.bin" in capsys.readouterr().err
 
 
 # ===================================================================
@@ -238,15 +337,17 @@ class TestCacheLifecycle:
         api.legacy.create_commit(
             repo_id=cls.repo_id,
             repo_type="model",
-            operations=[{
-                "action": "create",
-                "path": "cache_data.txt",
-                "type": "normal",
-                "size": len(file_bytes),
-                "sha256": "",
-                "content": content_b64,
-                "encoding": "base64",
-            }],
+            operations=[
+                {
+                    "action": "create",
+                    "path": "cache_data.txt",
+                    "type": "normal",
+                    "size": len(file_bytes),
+                    "sha256": "",
+                    "content": content_b64,
+                    "encoding": "base64",
+                }
+            ],
             commit_message="Add test file for cache tests",
             revision="master",
         )
@@ -321,11 +422,7 @@ class TestCacheLifecycle:
         assert exit_code == 0
 
         exit_code, out, err = run_cli(
-            ["cache", "clear",
-             "--repo-type", "model",
-             "--repo-id", self.repo_id,
-             "--cache-dir", cache2,
-             "--yes"],
+            ["cache", "clear", "--repo-type", "model", "--repo-id", self.repo_id, "--cache-dir", cache2, "--yes"],
             token=test_token,
             endpoint=test_endpoint,
         )

--- a/tests/cli/test_cache.py
+++ b/tests/cli/test_cache.py
@@ -314,6 +314,24 @@ class TestCacheVerifyExecute:
         assert "weights.bin" in capsys.readouterr().err
 
 
+    def test_missing_and_extra_warnings_include_bounded_paths(self, parser, mock_api, capsys):
+        mock_api.verify_cache.return_value = CacheVerification(
+            revision="master",
+            verified_path="/cache/snapshot",
+            missing_paths=[f"missing-{index}.txt" for index in range(11)],
+            extra_paths=["extra.txt"],
+        )
+        args = parser.parse_args(["cache", "verify", "owner/repo"])
+        with patch("modelscope_hub.cli.cache.make_api", return_value=mock_api):
+            _CacheVerify(args).execute()
+
+        err = capsys.readouterr().err
+        assert "missing-0.txt" in err
+        assert "missing-9.txt..." in err
+        assert "missing-10.txt" not in err
+        assert "extra.txt" in err
+
+
 # ===================================================================
 # Remote integration tests (existing)
 # ===================================================================

--- a/tests/test_cache_verification.py
+++ b/tests/test_cache_verification.py
@@ -38,6 +38,24 @@ def test_verify_local_directory_reports_all_categories(tmp_path):
     assert result.extra_paths == ["extra.txt"]
 
 
+def test_verify_local_directory_ignores_hidden_paths(tmp_path):
+    (tmp_path / "visible.txt").write_bytes(b"visible")
+    (tmp_path / ".DS_Store").write_bytes(b"metadata")
+    hidden_dir = tmp_path / ".git"
+    hidden_dir.mkdir()
+    (hidden_dir / "config").write_bytes(b"git config")
+
+    result = verify_cache(
+        "owner/repo",
+        "model",
+        {"visible.txt": _sha256(b"visible")},
+        local_dir=tmp_path,
+    )
+
+    assert result.checked_count == 1
+    assert result.extra_paths == []
+
+
 def test_verify_cached_snapshot(tmp_path):
     snapshot = tmp_path / "models" / "owner--repo" / "snapshots" / "master"
     snapshot.mkdir(parents=True)
@@ -52,6 +70,24 @@ def test_verify_cached_snapshot(tmp_path):
 
     assert result.checked_count == 1
     assert result.revision == "master"
+
+
+def test_verify_uses_main_as_default_cached_revision(tmp_path):
+    snapshots = tmp_path / "models" / "owner--repo" / "snapshots"
+    main_snapshot = snapshots / "main"
+    main_snapshot.mkdir(parents=True)
+    (snapshots / "dev").mkdir()
+    (main_snapshot / "config.json").write_bytes(b"{}")
+
+    result = verify_cache(
+        "owner/repo",
+        "model",
+        {"config.json": _sha256(b"{}")},
+        cache_dir=tmp_path,
+    )
+
+    assert result.checked_count == 1
+    assert result.revision == "main"
 
 
 def test_verify_accepts_plural_repo_type(tmp_path):

--- a/tests/test_cache_verification.py
+++ b/tests/test_cache_verification.py
@@ -54,6 +54,21 @@ def test_verify_cached_snapshot(tmp_path):
     assert result.revision == "master"
 
 
+def test_verify_accepts_plural_repo_type(tmp_path):
+    snapshot = tmp_path / "models" / "owner--repo" / "snapshots" / "master"
+    snapshot.mkdir(parents=True)
+    (snapshot / "config.json").write_bytes(b"{}")
+
+    result = verify_cache(
+        "owner/repo",
+        "models",
+        {"config.json": _sha256(b"{}")},
+        cache_dir=tmp_path,
+    )
+
+    assert result.checked_count == 1
+
+
 def test_verify_accepts_string_paths(tmp_path):
     local_dir = tmp_path / "local"
     local_dir.mkdir()
@@ -95,7 +110,7 @@ def test_api_passes_remote_sha256_metadata_to_verifier(tmp_path):
     expected_result = CacheVerification(revision="master", verified_path=str(tmp_path))
 
     with (
-        patch.object(api, "list_repo_files", return_value=files),
+        patch.object(api, "list_repo_files", return_value=files) as mocked_list,
         patch("modelscope_hub.api._verify_cache", return_value=expected_result) as mocked_verify,
     ):
         result = api.verify_cache("owner/repo", local_dir=tmp_path)
@@ -106,3 +121,37 @@ def test_api_passes_remote_sha256_metadata_to_verifier(tmp_path):
         "model",
         {"config.json": "abc"},
     )
+    mocked_list.assert_called_once_with(
+        "owner/repo",
+        "model",
+        revision="master",
+        recursive=True,
+    )
+
+
+def test_api_uses_resolved_cached_revision_for_remote_metadata(tmp_path):
+    snapshot = tmp_path / "models" / "owner--repo" / "snapshots" / "dev"
+    snapshot.mkdir(parents=True)
+    api = HubApi()
+
+    with (
+        patch.object(api, "list_repo_files", return_value=[]) as mocked_list,
+        patch("modelscope_hub.api._verify_cache") as mocked_verify,
+    ):
+        api.verify_cache("owner/repo", cache_dir=tmp_path)
+
+    mocked_list.assert_called_once_with(
+        "owner/repo",
+        "model",
+        revision="dev",
+        recursive=True,
+    )
+    assert mocked_verify.call_args.kwargs["revision"] == "dev"
+
+
+def test_file_info_positional_fields_remain_compatible():
+    info = FileInfo("file.txt", 10, "blob", "tree", None, {"sha256": "abc"})
+
+    assert info.type == "tree"
+    assert info.lfs == {"sha256": "abc"}
+    assert info.sha256 is None

--- a/tests/test_cache_verification.py
+++ b/tests/test_cache_verification.py
@@ -54,6 +54,21 @@ def test_verify_cached_snapshot(tmp_path):
     assert result.revision == "master"
 
 
+def test_verify_accepts_string_paths(tmp_path):
+    local_dir = tmp_path / "local"
+    local_dir.mkdir()
+    (local_dir / "config.json").write_bytes(b"{}")
+
+    result = verify_cache(
+        "owner/repo",
+        "model",
+        {"config.json": _sha256(b"{}")},
+        local_dir=str(local_dir),
+    )
+
+    assert result.checked_count == 1
+
+
 def test_verify_rejects_ambiguous_cached_revision(tmp_path):
     snapshots = tmp_path / "models" / "owner--repo" / "snapshots"
     (snapshots / "one").mkdir(parents=True)
@@ -61,6 +76,14 @@ def test_verify_rejects_ambiguous_cached_revision(tmp_path):
 
     with pytest.raises(CacheError, match="ambiguous"):
         verify_cache("owner/repo", "model", {}, cache_dir=tmp_path)
+
+
+def test_verify_reports_empty_snapshot_directory(tmp_path):
+    snapshots = tmp_path / "models" / "owner--repo" / "snapshots"
+    snapshots.mkdir(parents=True)
+
+    with pytest.raises(CacheError, match="No cached revisions"):
+        verify_cache("owner/repo", "model", {}, cache_dir=str(tmp_path))
 
 
 def test_api_passes_remote_sha256_metadata_to_verifier(tmp_path):

--- a/tests/test_cache_verification.py
+++ b/tests/test_cache_verification.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import hashlib
+from unittest.mock import patch
+
+import pytest
+
+from modelscope_hub._cache_manager import verify_cache
+from modelscope_hub.api import HubApi
+from modelscope_hub.errors import CacheError
+from modelscope_hub.types import CacheVerification, FileInfo
+
+
+def _sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def test_verify_local_directory_reports_all_categories(tmp_path):
+    (tmp_path / "good.txt").write_bytes(b"good")
+    (tmp_path / "bad.txt").write_bytes(b"bad")
+    (tmp_path / "extra.txt").write_bytes(b"extra")
+
+    result = verify_cache(
+        "owner/repo",
+        "model",
+        {
+            "good.txt": _sha256(b"good"),
+            "bad.txt": _sha256(b"expected"),
+            "missing.txt": _sha256(b"missing"),
+            "without-hash.txt": None,
+        },
+        local_dir=tmp_path,
+    )
+
+    assert result.checked_count == 2
+    assert [item.path for item in result.mismatches] == ["bad.txt"]
+    assert result.missing_paths == ["missing.txt", "without-hash.txt"]
+    assert result.extra_paths == ["extra.txt"]
+
+
+def test_verify_cached_snapshot(tmp_path):
+    snapshot = tmp_path / "models" / "owner--repo" / "snapshots" / "master"
+    snapshot.mkdir(parents=True)
+    (snapshot / "config.json").write_bytes(b"{}")
+
+    result = verify_cache(
+        "owner/repo",
+        "model",
+        {"config.json": _sha256(b"{}")},
+        cache_dir=tmp_path,
+    )
+
+    assert result.checked_count == 1
+    assert result.revision == "master"
+
+
+def test_verify_rejects_ambiguous_cached_revision(tmp_path):
+    snapshots = tmp_path / "models" / "owner--repo" / "snapshots"
+    (snapshots / "one").mkdir(parents=True)
+    (snapshots / "two").mkdir()
+
+    with pytest.raises(CacheError, match="ambiguous"):
+        verify_cache("owner/repo", "model", {}, cache_dir=tmp_path)
+
+
+def test_api_passes_remote_sha256_metadata_to_verifier(tmp_path):
+    api = HubApi()
+    files = [
+        FileInfo(path="config.json", sha256="abc"),
+        FileInfo(path="folder", type="tree"),
+    ]
+    expected_result = CacheVerification(revision="master", verified_path=str(tmp_path))
+
+    with (
+        patch.object(api, "list_repo_files", return_value=files),
+        patch("modelscope_hub.api._verify_cache", return_value=expected_result) as mocked_verify,
+    ):
+        result = api.verify_cache("owner/repo", local_dir=tmp_path)
+
+    assert result is expected_result
+    assert mocked_verify.call_args.args[:3] == (
+        "owner/repo",
+        "model",
+        {"config.json": "abc"},
+    )


### PR DESCRIPTION
Closes #36.

### Summary

- add ms cache verify for cached snapshots and regular local directories
- compare local files with SHA-256 metadata returned by ModelScope Hub
- return a non-zero status for checksum mismatches
- warn for missing, extra, or unverifiable files, with strict missing/extra flags
- expose a structured SDK verification result and document the CLI

### Validation

- 39 targeted tests passed; 6 remote lifecycle tests skipped because credentials are not configured
- full non-remote suite: 474 passed; 2 pre-existing unrelated failures remain in test_mcp.py::TestMcpDeployExecute::test_deploy and test_utils.py::TestParseTimestamp::test_datetime_passthrough
- queried public Qwen/Qwen3-0.6B metadata to confirm the Hub returns per-file 64-character SHA-256 values

### AI-assisted contribution disclosure

This contribution was prepared with an AI coding assistant. I reviewed the implementation and tests and remain responsible for the submitted code. The repository does not currently document an AI contribution policy, so #36 explicitly asks the maintainers to confirm whether disclosed AI-assisted contributions are accepted.