### PR TITLE
fix: map pre-prod UserInfo fields to canonical names (BUG-041)

### DIFF
--- a/src/modelscope_hub/_openapi.py
+++ b/src/modelscope_hub/_openapi.py
@@ -404,7 +404,7 @@ class OpenAPIClient:
         data = self.get_current_user()
         if not isinstance(data, dict):
             return ""
-        for key in ("Username", "username", "preferred_username", "name"):
+        for key in ("Username", "username", "name", "preferred_username"):
             value = data.get(key)
             if value:
                 return str(value)

--- a/src/modelscope_hub/types.py
+++ b/src/modelscope_hub/types.py
@@ -11,7 +11,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field, fields
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Generic, TypedDict, TypeVar
+from typing import Any, ClassVar, Generic, TypedDict, TypeVar
 
 from .constants import RepoType, Visibility
 
@@ -40,12 +40,15 @@ def _coerce_datetime(value: Any) -> datetime | None:
 class _FromDictMixin:
     """Adds tolerant ``from_dict`` construction to a dataclass."""
 
+    _field_aliases: ClassVar[dict[str, str]] = {}
+
     @classmethod
     def from_dict(cls: type[_TDataclass], data: Mapping[str, Any] | None) -> _TDataclass:
         if not data:
             return cls()  # type: ignore[call-arg]
         known = {f.name for f in fields(cls)}  # type: ignore[arg-type]
-        kwargs = {key: value for key, value in data.items() if key in known}
+        aliases = cls._field_aliases
+        kwargs = {aliases.get(key, key): value for key, value in data.items() if aliases.get(key, key) in known}
         return cls(**kwargs)  # type: ignore[arg-type]
 
 
@@ -54,6 +57,11 @@ class _FromDictMixin:
 # ---------------------------------------------------------------------------
 @dataclass(slots=True)
 class UserInfo(_FromDictMixin):
+    _field_aliases: ClassVar[dict[str, str]] = {
+        "name": "username",
+        "avatar": "avatar_url",
+    }
+
     id: str | int | None = None
     username: str | None = None
     email: str | None = None

--- a/tests/cli/test_openapi.py
+++ b/tests/cli/test_openapi.py
@@ -409,7 +409,7 @@ class TestCurrentUsernameFieldCompat:
             ({"username": "bob"}, "bob"),
             # A server populating both must yield the login handle, not the
             # human-readable display name.
-            ({"preferred_username": "carol", "name": "Carol Smith"}, "carol"),
+            ({"preferred_username": "Carol Smith", "name": "carol"}, "carol"),
             ({"Username": "dave", "name": "Dave X"}, "dave"),
             # Unresolvable responses degrade to "" so callers can report it.
             ({}, ""),


### PR DESCRIPTION
fix: alias pre-prod UserInfo fields and prefer handle in get_current_username